### PR TITLE
Improve automatic detection of cross-domain AJAX requests

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -84,7 +84,11 @@ $.TokenList = function (input, settings) {
 
     // Make a smart guess about cross-domain if it wasn't explicitly specified
     if(settings.crossDomain === undefined) {
-        settings.crossDomain = (location.href.split(/\/+/g)[1] !== settings.url.split(/\/+/g)[1]);
+        if (settings.url.charAt(0) == '/') {
+            settings.crossDomain = false;
+        } else {
+            settings.crossDomain = (location.href.split(/\/+/g)[1] !== settings.url.split(/\/+/g)[1]);
+        }
     }
 
     // Build class names


### PR DESCRIPTION
This is a fix for Issue 42: "No results populated despite correct json format."

The automatic cross-domain detection incorrectly detects absolute URLS with no host name (i.e. /Crop/GetMatchingCrops) as cross-domain requests. To fix, I added a line of code that sets the "crossDomain" parameter to "false" if the URL's first character is a slash.
