### PR TITLE
onResult when getting results from local_data

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -686,6 +686,9 @@ $.TokenList = function (input, url_or_data, settings) {
                     return row.name.toLowerCase().indexOf(query.toLowerCase()) > -1;
                 });
 
+                if($.isFunction(settings.onResult)) {
+                    results = settings.onResult.call(this, results);
+                }
                 cache.add(query, results);
                 populate_dropdown(query, results);
             }


### PR DESCRIPTION
We are just using local_data so the onResult callback was not being called.  I think it makes sense to have the onResult callback called regardless of whether it is an JSON request or if it is searching on local data.
