### PR TITLE
Allowing to change the value of the tokens held in the orignal input

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -367,10 +367,7 @@ $.TokenList = function (input, url_or_data, settings) {
         selected_token_index++;
 
         // Update the hidden input
-        var token_values = $.map(saved_tokens, function (el) {
-            return el[settings.tokenValue];
-        });
-        hidden_input.val(token_values.join(settings.tokenDelimiter));
+        update_hidden_input(saved_tokens, hidden_input);
 
         token_count += 1;
 
@@ -494,10 +491,7 @@ $.TokenList = function (input, url_or_data, settings) {
         if(index < selected_token_index) selected_token_index--;
 
         // Update the hidden input
-        var token_ids = $.map(saved_tokens, function (el) {
-            return el.id;
-        });
-        hidden_input.val(token_ids.join(settings.tokenDelimiter));
+        update_hidden_input(saved_tokens, hidden_input);
 
         token_count -= 1;
 
@@ -512,6 +506,15 @@ $.TokenList = function (input, url_or_data, settings) {
         if($.isFunction(callback)) {
             callback.call(hidden_input,token_data);
         }
+    }
+
+    // Update the hidden input box value
+    function update_hidden_input(saved_tokens, hidden_input) {
+        var token_values = $.map(saved_tokens, function (el) {
+            return el[settings.tokenValue];
+        });
+        hidden_input.val(token_values.join(settings.tokenDelimiter));
+
     }
 
     // Hide and clear the results dropdown


### PR DESCRIPTION
By default, the value of the original input box will be a concatenation of IDs.
It would be nice to be able to hold the name here instead, to e.g. allow the creation of new tokens on the fly.

This patch makes this possible by adding a new configuration option:

```
$('#my-input').tokenInput({
  tokenValue: 'name' // defaults to 'id'
});
```

leads to appending names instead of the IDs.
