### PR TITLE
Not showing dropdown and inputbox anymore if tokenLimit is reached by prePopulate (Fix Issue: #50, #53)

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -375,6 +375,12 @@ $.TokenList = function (input, url_or_data, settings) {
 
         token_count += 1;
 
+        // Check the token limit
+        if(settings.tokenLimit !== null && token_count >= settings.tokenLimit) {
+            input_box.hide();
+            hide_dropdown();
+        }
+
         return this_token;
     }
 


### PR DESCRIPTION
This fixes the Issues #50 and #53 and prevents that a new selection is possible when limit is already reached by prePopulated Items.
