### PR TITLE
Dropdown positioning issues

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -13,6 +13,12 @@
         });
     });
     </script>
+
+    <style type="text/css">
+        .token-input-list-facebook {
+            width: 500px !important;
+        }
+    </style>
 </head>
 
 <body>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -525,7 +525,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 position: "absolute",
                 top: $(token_list).offset().top + $(token_list).outerHeight(),
                 left: $(token_list).offset().left,
-                zindex: 999
+                zIndex: 999
             })
             .show();
     }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -528,8 +528,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 position: "absolute",
                 top: 0,
                 left: 0,
-                width: token_list.width(),
-                zIndex: 999
+                width: token_list.width()
             })
             .show();
     }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -288,9 +288,12 @@ $.TokenList = function (input, url_or_data, settings) {
         .append(input_box);
 
     // The list to store the dropdown items in
+    var dropdown_parent = $("<div>")
+        .insertAfter(token_list)
+        .css({position: 'relative'});
     var dropdown = $("<div>")
         .addClass(settings.classes.dropdown)
-        .appendTo("body")
+        .appendTo(dropdown_parent)
         .hide();
 
     // Magic element to help us resize the text input
@@ -523,8 +526,9 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: $(token_list).offset().top + $(token_list).outerHeight(),
-                left: $(token_list).offset().left,
+                top: 0,
+                left: 0,
+                width: token_list.width(),
                 zIndex: 999
             })
             .show();

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -523,14 +523,36 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     function show_dropdown() {
-        dropdown
-            .css({
-                position: "absolute",
-                top: 0,
-                left: 0,
-                width: token_list.width()
-            })
-            .show();
+        var dropdown_height = $("ul", dropdown).height(),
+            bottom_height_left = $(document).height() - $(token_list).offset().top - $(token_list).outerHeight(),
+            top_height_left = $(token_list).offset().top;
+
+        if (dropdown_height > bottom_height_left && dropdown_height < top_height_left) {
+            // Show dropdown to the top, ergo 'dropup'
+            dropdown
+                .css({
+                    position: "absolute",
+                    bottom: $(token_list).outerHeight(),
+                    top: '',
+                    left: 0,
+                    width: token_list.width()
+                })
+                .addClass('token-input-dropdown-top-facebook')
+                .removeClass('token-input-dropdown-bottom-facebook')
+                .show();
+        } else {
+            dropdown
+                .css({
+                    position: "absolute",
+                    top: 0,
+                    bottom: '',
+                    left: 0,
+                    width: token_list.width()
+                })
+                .removeClass('token-input-dropdown-top-facebook')
+                .addClass('token-input-dropdown-bottom-facebook')
+                .show();
+        }
     }
 
     function show_dropdown_searching () {

--- a/styles/token-input-facebook.css
+++ b/styles/token-input-facebook.css
@@ -9,7 +9,6 @@ ul.token-input-list-facebook {
     font-size: 12px;
     font-family: Verdana;
     min-height: 1px;
-    z-index: 999;
     margin: 0;
     padding: 0;
     background-color: #fff;
@@ -80,7 +79,7 @@ div.token-input-dropdown-facebook {
     cursor: default;
     font-size: 11px;
     font-family: Verdana;
-    z-index: 1;
+    z-index: 1005;
 }
 
 div.token-input-dropdown-facebook p {

--- a/styles/token-input-facebook.css
+++ b/styles/token-input-facebook.css
@@ -73,13 +73,17 @@ div.token-input-dropdown-facebook {
     position: absolute;
     background-color: #fff;
     overflow: hidden;
-    border-left: 1px solid #ccc;
-    border-right: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
+    border: 1px solid #ccc;
     cursor: default;
     font-size: 11px;
     font-family: Verdana;
     z-index: 1005;
+}
+div.token-input-dropdown-bottom-facebook {
+    border-top: none;
+}
+div.token-input-dropdown-top-facebook {
+    border-bottom: none;
 }
 
 div.token-input-dropdown-facebook p {

--- a/styles/token-input-facebook.css
+++ b/styles/token-input-facebook.css
@@ -72,7 +72,6 @@ li.token-input-input-token-facebook {
 
 div.token-input-dropdown-facebook {
     position: absolute;
-    width: 400px;
     background-color: #fff;
     overflow: hidden;
     border-left: 1px solid #ccc;

--- a/styles/token-input-mac.css
+++ b/styles/token-input-mac.css
@@ -28,7 +28,6 @@ ul.token-input-list-mac {
     font-size: 12px;
     font-family: Verdana;
     min-height: 1px;
-    z-index: 999;
     margin: 0;
     padding: 3px;
     background: transparent;
@@ -131,6 +130,7 @@ div.token-input-dropdown-mac {
     -moz-box-shadow: 0 5px 20px 0 rgba(0,0,0,0.25);
     -webkit-box-shadow: 0 5px 20px 0 rgba(0,0,0,0.25);
     clip:rect(0px, 1000px, 1000px, -10px);
+    z-index: 1005;
 }
 
 div.token-input-dropdown-mac p {

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -8,7 +8,6 @@ ul.token-input-list {
     cursor: text;
     font-size: 12px;
     font-family: Verdana;
-    z-index: 999;
     margin: 0;
     padding: 0;
     background-color: #fff;
@@ -72,7 +71,7 @@ div.token-input-dropdown {
     cursor: default;
     font-size: 12px;
     font-family: Verdana;
-    z-index: 1;
+    z-index: 1005;
 }
 
 div.token-input-dropdown p {

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -64,7 +64,6 @@ li.token-input-selected-token span {
 
 div.token-input-dropdown {
     position: absolute;
-    width: 400px;
     background-color: #fff;
     overflow: hidden;
     border-left: 1px solid #ccc;

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -65,13 +65,17 @@ div.token-input-dropdown {
     position: absolute;
     background-color: #fff;
     overflow: hidden;
-    border-left: 1px solid #ccc;
-    border-right: 1px solid #ccc;
-    border-bottom: 1px solid #ccc;
+    border: 1px solid #ccc;
     cursor: default;
     font-size: 12px;
     font-family: Verdana;
     z-index: 1005;
+}
+div.token-input-dropdown-bottom {
+    border-top: none;
+}
+div.token-input-dropdown-top {
+    border-bottom: none;
 }
 
 div.token-input-dropdown p {


### PR DESCRIPTION
With the current solution
- Scrolling of inner elements (overflow: auto) will keep the dropdown fixed as it is attached to body. The visual effect is that the dropdown separates from the widget.
- Pages with extensive z-index usage will have issues, as the dropdown adjusts to the body.

This commit fixes these issues by attaching the dropdown to the same parent as the token-input.

Placing the dropdown with the parent has the downside of interfering with CSS overflow settings.
