### PR TITLE
HTML5 placeholder support

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -49,7 +49,9 @@
                 {id: 41, name: "C"},
                 {id: 43, name: "C++"},
                 {id: 47, name: "Java"}
-            ]);
+            ], {
+                placeholder: 'Select your favourite programming languages'
+            });
         });
         </script>
     </div>
@@ -62,7 +64,8 @@
         <script type="text/javascript">
         $(document).ready(function() {
             $("#demo-input-facebook-theme").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
-                theme: "facebook"
+                theme: "facebook",
+                placeholder: 'Select a TV show'
             });
         });
         </script>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -15,6 +15,7 @@ var DEFAULT_SETTINGS = {
     noResultsText: "No results",
     searchingText: "Searching...",
     deleteText: "&times;",
+    placeholder: null,
     searchDelay: 300,
     minChars: 1,
     tokenLimit: null,
@@ -234,6 +235,9 @@ $.TokenList = function (input, url_or_data, settings) {
             }
         });
 
+    if (settings.placeholder)
+        input_box.attr("placeholder", settings.placeholder)
+
     // Keep a reference to the original input box
     var hidden_input = $(input)
                            .hide()
@@ -320,7 +324,8 @@ $.TokenList = function (input, url_or_data, settings) {
         });
     }
 
-
+    // Resize input to maximum width so the placeholder can be seen
+    resize_input();
 
     //
     // Private functions
@@ -329,10 +334,14 @@ $.TokenList = function (input, url_or_data, settings) {
     function resize_input() {
         if(input_val === (input_val = input_box.val())) {return;}
 
+        // Get width left on the current line
+        var width_left = token_list.width() - input_box.offset().left - token_list.offset().left;
         // Enter new content into resizer and resize input accordingly
         var escaped = input_val.replace(/&/g, '&amp;').replace(/\s/g,' ').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         input_resizer.html(escaped);
-        input_box.width(input_resizer.width() + 30);
+        // Get maximum width, minimum the size of input and maximum the widget's width
+        input_box.width(Math.min(token_list.width(), 
+                                 Math.max(width_left, input_resizer.width() + 30)));
     }
 
     function is_printable_character(keycode) {
@@ -400,6 +409,9 @@ $.TokenList = function (input, url_or_data, settings) {
                 return;
             }
         }
+
+        // Squeeze input_box so we force no unnecessary line break
+        input_box.width(0);
 
         // Insert the new tokens
         insert_token(li_data.id, li_data.name);

--- a/styles/token-input-facebook.css
+++ b/styles/token-input-facebook.css
@@ -19,7 +19,6 @@ ul.token-input-list-facebook {
 
 ul.token-input-list-facebook li input {
     border: 0;
-    width: 100px;
     padding: 3px 8px;
     background-color: white;
     margin: 2px 0;

--- a/styles/token-input-mac.css
+++ b/styles/token-input-mac.css
@@ -106,7 +106,6 @@ li.token-input-input-token-mac {
 
 li.token-input-input-token-mac input {
   border: 0;
-  width: 100px;
   padding: 3px;
   background-color: transparent;
   margin: 0;

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -22,7 +22,6 @@ ul.token-input-list li {
 
 ul.token-input-list li input {
     border: 0;
-    width: 350px;
     padding: 3px 8px;
     background-color: white;
     -webkit-appearance: caret;


### PR DESCRIPTION
Adds the HTML5 placeholder attribute to the token input if configured, e.g:

```
$("#input").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
    placeholder: 'Select a TV show'
});
```

Tested in Firefox 4 & Chrome. Support for older browsers can probably be given by including jquery.placeholder.js
- Makes sure the input widget gets the maximum space possible (i.e. at least the size of the input and maximum the size of the widget).
- Removing width from css as it is now set automatically.
- On the way fixes long token input not scrolling if widget width is surpassed
