### PR TITLE
Added option not to parse ajax params + error callback.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -29,7 +29,8 @@ var DEFAULT_SETTINGS = {
     animateDropdown: true,
     onResult: null,
     onAdd: null,
-    onDelete: null
+    onDelete: null,
+    parseAjaxParams: true
 };
 
 // Default classes to use when theming
@@ -648,7 +649,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 // Extract exisiting get params
                 var ajax_params = {};
                 ajax_params.data = {};
-                if(settings.url.indexOf("?") > -1) {
+                if(settings.parseAjaxParams && settings.url.indexOf("?") > -1) {
                     var parts = settings.url.split("?");
                     ajax_params.url = parts[0];
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -28,6 +28,7 @@ var DEFAULT_SETTINGS = {
     processPrePopulate: false,
     animateDropdown: true,
     onResult: null,
+    onError: null,
     onAdd: null,
     onDelete: null,
     parseAjaxParams: true
@@ -677,6 +678,18 @@ $.TokenList = function (input, url_or_data, settings) {
                   }
                   cache.add(query, settings.jsonContainer ? results[settings.jsonContainer] : results);
 
+                  // only populate the dropdown if the results are associated with the active search query
+                  if(input_box.val().toLowerCase() === query) {
+                      populate_dropdown(query, settings.jsonContainer ? results[settings.jsonContainer] : results);
+                  }
+                };
+                
+                // Attach the error callback
+                ajax_params.error = function(results) {
+                  if($.isFunction(settings.onError)) {
+                      results = settings.onError.call(hidden_input, results);
+                  }
+                  
                   // only populate the dropdown if the results are associated with the active search query
                   if(input_box.val().toLowerCase() === query) {
                       populate_dropdown(query, settings.jsonContainer ? results[settings.jsonContainer] : results);


### PR DESCRIPTION
We have a scenario where we're fetching parameters such as foobar[]= (Rails arrays) from the query string. They get parsed and then encoded into a foobar%5B... which Rails doesn't parse. There's no need to encode those and I didn't find a way to prevent it.

If anyone has a better suggestion, do let me know. Otherwise this is a pretty innocent change that basically preserves the url as it was set in code.
