### PR TITLE
Do not parse parameter values that contain the character =

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -317,6 +317,7 @@ $.TokenList = function (input, url_or_data, settings) {
     if(li_data && li_data.length) {
         $.each(li_data, function (index, value) {
             insert_token(value.id, value.name);
+            // check for token limit
             if(settings.tokenLimit === null || parseInt(settings.tokenLimit) > parseInt(token_count)) {
               input_box.focus();
             } else {


### PR DESCRIPTION
We have a scenario where we're fetching parameters such as ..&p_request=PLUGIN=FOO from the query string. They get parsed and the second part is not appended. I didn't find a way to prevent them. A solution that is compatible to the current may be this little change.
