### PR TITLE
Adding an option to disable backspace ability to remove items

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -30,7 +30,8 @@ var DEFAULT_SETTINGS = {
     onResult: null,
     onAdd: null,
     onDelete: null,
-    idPrefix: "token-input-"
+    idPrefix: "token-input-",
+    backspaceDeleteItem: true
 };
 
 // Default classes to use when theming
@@ -219,8 +220,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
                 case KEY.BACKSPACE:
                     previous_token = input_token.prev();
-
-                    if(!$(this).val().length) {
+                    if(!$(this).val().length && settings.backspaceDeleteItem) {
                         if(selected_token) {
                             delete_token($(selected_token));
                         } else if(previous_token.length) {


### PR DESCRIPTION
Sometimes, specially when you are using the vertical theme, the user
mistakenly erases some items by holding the backspace. To avoid this
behavior I'm including an option to disable the ability of the backspace
to remove the already added items.
