### PR TITLE
Adding a public method to fetch the token objects programatically

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -93,7 +93,10 @@ var methods = {
     remove: function(item) {
         this.data("tokenInputObject").remove(item);
         return this;
-    }
+    },
+    get: function() {
+    	return this.data("tokenInputObject").getTokens();
+   	}
 }
 
 // Expose the .tokenInput function to jQuery as a plugin
@@ -380,6 +383,10 @@ $.TokenList = function (input, url_or_data, settings) {
             }
         });
     }
+    
+    this.getTokens = function() {
+   		return saved_tokens;
+   	}
 
     //
     // Private functions


### PR DESCRIPTION
This patch adds a public "get" method that returns all active token objects (id, name) programatically.

Usage:

```
var tokens = ('#tokens').tokenInput('get');
```
