### PR TITLE
New features: propertyToSearch, resultsFormatter and tokenFormatter

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -243,5 +243,188 @@
         });
         </script>
     </div>
+    
+    <h2>Local Data Search with custom propertyToSearch, resultsFormatter and tokenFormatter</h2>
+    <div>
+        <input type="text" id="demo-input-local-custom-formatters" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-local-custom-formatters").tokenInput([{
+                "first_name": "Arthur",
+                "last_name": "Godfrey",
+                "email": "arthur_godfrey@nccu.edu",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Adam",
+                "last_name": "Johnson",
+                "email": "wravo@yahoo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Jeff",
+                "last_name": "Johnson",
+                "email": "bballnine@hotmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Adriana",
+                "last_name": "Jameson",
+                "email": "adriana.jameson@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Adriano",
+                "last_name": "Pooley",
+                "email": "adrianolpooley@lautau.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alcir",
+                "last_name": "Reis",
+                "email": "alcirreis@yahoo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Jack",
+                "last_name": "Cunningham",
+                "email": "jcunningham@hotmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alejandro",
+                "last_name": "Forbes",
+                "email": "alejandforbes@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alessandra",
+                "last_name": "Mineiro",
+                "email": "alc_mineiro@aol.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alex",
+                "last_name": "Frazo",
+                "email": "alex.frazo@yahoo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alexandre",
+                "last_name": "Crawford",
+                "email": "xandycrawford@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alexandre",
+                "last_name": "Lalwani",
+                "email": "alexandrelalwani@globo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alexandre",
+                "last_name": "Jokos",
+                "email": "alex.jokos@gmail.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alexandre",
+                "last_name": "Paro",
+                "email": "alexandre.paro@uol.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Niemeyer",
+                "email": "a.niemeyer@globo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Alyssa",
+                "last_name": "Fortes",
+                "email": "afort287@yahoo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Amit",
+                "last_name": "Alvarenga",
+                "email": "amit.alva@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Ana Bia",
+                "last_name": "Borges",
+                "email": "abborges@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Ana",
+                "last_name": "Akamine",
+                "email": "ana.akamine@uol.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Anderson",
+                "last_name": "Tovoros",
+                "email": "alvarenga.tovoros@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Borges",
+                "email": "andreborges@hotmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Wexler",
+                "email": "andre.wexler@aol.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Williams",
+                "email": "awilly@yahoo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Sanford",
+                "email": "andre.sanford@gmail.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Wayne",
+                "email": "andrewayne@uol.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Jackson",
+                "email": "andre.jackson@yahoo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Jolly",
+                "email": "andre.jolly@uol.com.br",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "first_name": "Andre",
+                "last_name": "Henderson",
+                "email": "andre.henderson@globo.com",
+                "url": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            }
+          ], {
+              propertyToSearch: "first_name",
+              resultsFormatter: function(item){ return "<li>" + "<img src='" + item.url + "' title='" + item.first_name + " " + item.last_name + "' height='25px' width='25px' />" + "<div style='display: inline-block; padding-left: 10px;'><div class='full_name'>" + item.first_name + " " + item.last_name + "</div><div class='email'>" + item.email + "</div></div></li>" },
+              tokenFormatter: function(item) { return "<li><p>" + item.first_name + " " + item.last_name + "</p></li>" },
+          });
+        });
+        </script>
+    </div>
 </body>
 </html>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -11,7 +11,7 @@
 (function ($) {
 // Default settings
 var DEFAULT_SETTINGS = {
-    propertyToSearch: "first_name",
+    propertyToSearch: "name",
     hintText: "Type in a search term",
     noResultsText: "No results",
     searchingText: "Searching...",


### PR DESCRIPTION
1) `propertyToSearch` parameter allows the user to query a field other than "name". The default is "name"

2) `resultsFormatter` and `tokenFormatter` permit the user to override the default `<li> + item.name + </li>` results and replace them with a function that receives a json object and returns a populated html string. This feature permits the user to pretty much any templating framework they want with jQuery-tokeninput. The highlighter still works with this and will only highlight terms in values that correspond to the `propertyToSearch` key. This highlighting feature isn't perfect but it's more than good enough for 99% of use cases and the user is unlikely to notice the edge cases when it highlights terms it shouldn't in the template.

It would be nice to upgrade propertyToSearch to propertiesToSearch, permitting the user to supply an array of fields to search such as `['first_name', 'last_name']`. I might try doing this later, but it's a bit more complex to implement at the moment.
