### PR TITLE
Using insert_token rather than add_token for programatically adding a token

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -369,7 +369,7 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     this.add = function(item) {
-        add_token(item);
+        insert_token(item);
     }
 
     this.remove = function(item) {


### PR DESCRIPTION
Using insert_token rather than add_token for programatically adding tokens in order not to get a focus on the dropdown when programmatically adding a token
