### PR TITLE
fixed json example for prePopulate option

### DIFF
--- a/index.md
+++ b/index.md
@@ -153,7 +153,7 @@ tokenValue
 
 prePopulate
 :   Prepopulate the tokeninput with existing data. Set to an array of JSON
-    objects, eg: `[{id: 3, name: "test", id: 5, name: "awesome"}]`
+    objects, eg: `[{id: 3, name: "test"}, {id: 5, name: "awesome"}]`
     to pre-fill the input. *default: null* [(demo)](demo.html#pre-populated).
 
 preventDuplicates


### PR DESCRIPTION
```
diff --git a/index.md b/index.md
index 7fee899..c17e971 100644
--- a/index.md
+++ b/index.md
@@ -153,7 +153,7 @@ tokenValue

 prePopulate
 :   Prepopulate the tokeninput with existing data. Set to an array of JSON
-    objects, eg: `[{id: 3, name: "test", id: 5, name: "awesome"}]`
+    objects, eg: `[{id: 3, name: "test"}, {id: 5, name: "awesome"}]`
     to pre-fill the input. *default: null* [(demo)](demo.html#pre-populated).

 preventDuplicates
@@ -221,4 +221,4 @@ License
 -------
 Tokeninput is released under a dual license. You can choose either the GPL or
 MIT license depending on the project you are using it in and how you wish to
-use it.
\ No newline at end of file
+use it.
```
