### PR TITLE
Fixed compatibility with older versions of jQuery

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -133,7 +133,7 @@ $.TokenList = function (input, url_or_data, settings) {
     //
 
     // Configure the data source
-    if($.type(url_or_data) === "string" || $.type(url_or_data) === "function") {
+    if(typeof(url_or_data) === "string" || typeof(url_or_data) === "function") {
         // Set the url to query against
         settings.url = url_or_data;
 


### PR DESCRIPTION
Fixed compatibility with older versions of jQuery. This is essentially the same fix as https://github.com/loopj/jquery-tokeninput/commit/238ba005368dde78f820e6fc68ab328ed00a480b except at some point between then and now it was reverted.
