### PR TITLE
Fixed bug where 'id' property was used for duplicate checking rather than settings.tokenValue.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -460,7 +460,8 @@ $.TokenList = function (input, url_or_data, settings) {
             });
 
         // Store data on the token
-        var token_data = {"id": item.id};
+        var token_data = {};
+        token_data[settings.tokenValue] = item[settings.tokenValue];
         token_data[settings.propertyToSearch] = item[settings.propertyToSearch];
         $.data(this_token.get(0), "tokeninput", item);
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -492,7 +492,7 @@ $.TokenList = function (input, url_or_data, settings) {
             token_list.children().each(function () {
                 var existing_token = $(this);
                 var existing_data = $.data(existing_token.get(0), "tokeninput");
-                if(existing_data && existing_data.id === item.id) {
+                if(existing_data && existing_data[settings.tokenValue] === item[settings.tokenValue]) {
                     found_existing_token = existing_token;
                     return false;
                 }


### PR DESCRIPTION
add_token was explicitly checking for 'id' property for duplicate checking. If user passed in a tokenValue via settings, 'id' would be undefined. In this case, adding multiple items through $(..).tokenInput('add', {..}) became impossible.
