### PR TITLE
Escape special characters in regular expression

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -20,7 +20,7 @@ var DEFAULT_SETTINGS = {
     jsonContainer: null,
     contentType: "json",
 
-	// Prepopulation settings
+    // Prepopulation settings
     prePopulate: null,
     processPrePopulate: false,
 
@@ -89,6 +89,11 @@ var KEY = {
     NUMPAD_ENTER: 108,
     COMMA: 188
 };
+
+// Escape special characters which are used in regular expressions
+RegExp.escape = function(text) {
+    return text.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
+}
 
 // Additional public (exposed) methods
 var methods = {
@@ -651,11 +656,11 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Highlight the query part of the search term
     function highlight_term(value, term) {
-        return value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + term + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<b>$1</b>");
+        return value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + RegExp.escape(term) + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<b>$1</b>");
     }
 
     function find_value_and_highlight_term(template, value, term) {
-        return template.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + value + ")(?![^<>]*>)(?![^&;]+;)", "g"), highlight_term(value, term));
+        return template.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + RegExp.escape(value) + ")(?![^<>]*>)(?![^&;]+;)", "g"), highlight_term(value, term));
     }
 
     // Populate the results dropdown with some results


### PR DESCRIPTION
Special characters used in regular expressions should be escaped from the
user's input during highlighting as it breaks the dropdown list and may
introduce the possibility of injections.

As can be seen in the [Local Data Search](http://loopj.com/jquery-tokeninput/demo.html) example, entering `C++` does not work correctly and results in

```
Uncaught SyntaxError: Invalid regular expression: /(?![^&;]+;)(?!<[^<>]*)(C++)(?![^<>]*>)(?![^&;]+;)/: Nothing to repeat
```
