### PR TITLE
Empty text (added settings parameter for default text)

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -33,6 +33,7 @@ var DEFAULT_SETTINGS = {
     theme: null,
     resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
     tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
+    emptyText: "Search",
 
     // Tokenization settings
     tokenLimit: null,
@@ -187,7 +188,11 @@ $.TokenList = function (input, url_or_data, settings) {
             outline: "none"
         })
         .attr("id", settings.idPrefix + input.id)
+        .attr("value", settings.emptyText)
         .focus(function () {
+            if (settings.emptyText == $(this).val() ) { 
+                $(this).val("");
+            }
             if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
                 show_dropdown_hint();
             }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -1,7 +1,7 @@
 /*
  * jQuery Plugin: Tokenizing Autocomplete Text Entry
  * Version 1.6.0
- *
+ * 
  * Copyright (c) 2009 James Smith (http://loopj.com)
  * Licensed jointly under the GPL and MIT licenses,
  * choose which one suits your project best!


### PR DESCRIPTION
My update adds a default text option for when the tokeninput-ized search box is loaded. For example, you may want it populated with "Global Search". Also added code on the .focus to check if that text is still there and blitz it if so.

Thanks for creating tokeninput... It has been quite useful so far.
- Ben

Disclaimer: This is my first attempt at contribution to a library... and I am still getting used to git and github. So... my gitting may be a bit ham-handed... I actually forked, then made changes on my master... then noticed that github suggested creating a topic branch. So my last commit to my topic branch is just touching the file. 

Second Disclaimer: This is a bit of a hack, and my js skills are not great. 
