### PR TITLE
The removed element from UI hasn't been removed from the hidden token input 

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -588,7 +588,7 @@ $.TokenList = function (input, url_or_data, settings) {
         input_box.focus();
 
         // Remove this token from the saved list
-        saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));
+        saved_tokens = saved_tokens.slice(0,index-1).concat(saved_tokens.slice(index));
         if(index < selected_token_index) selected_token_index--;
 
         // Update the hidden input


### PR DESCRIPTION
The removed element from UI hasn't been removed from the hidden token input so that we have inconsistent data. The issue was occuring because there was a mistake around where to slice the array. The right position to slice the array is at index-1 since it starts on 0
