### PR TITLE
Allow hintText to be a watermark in the input box

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -84,6 +84,20 @@
         </script>
     </div>
 
+    <h2 id="hint-as-watermark">Hint Text as Input Box Watermark</h2>
+    <div>
+        <input type="text" id="demo-input-hint-as-watermark" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-hint-as-watermark").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
+                hintText: "Type in a search term...",
+                showHintAsWatermark: true
+            });
+        });
+        </script>
+    </div>
+
 
     <h2 id="custom-delete">Custom Delete Icon</h2>
     <div>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -25,6 +25,7 @@ var DEFAULT_SETTINGS = {
     processPrePopulate: false,
 
     // Display settings
+    showHintAsWatermark: false,
     hintText: "Type in a search term",
     noResultsText: "No results",
     searchingText: "Searching...",
@@ -61,7 +62,8 @@ var DEFAULT_CLASSES = {
     dropdownItem: "token-input-dropdown-item",
     dropdownItem2: "token-input-dropdown-item2",
     selectedDropdownItem: "token-input-selected-dropdown-item",
-    inputToken: "token-input-input-token"
+    inputToken: "token-input-input-token",
+    watermark: "token-input-watermark-applied"
 };
 
 // Input box position "enum"
@@ -189,12 +191,20 @@ $.TokenList = function (input, url_or_data, settings) {
         .attr("id", settings.idPrefix + input.id)
         .focus(function () {
             if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
-                show_dropdown_hint();
+                if (settings.showHintAsWatermark) {
+                    toggle_watermark(false);
+                } else {
+                    show_dropdown_hint();
+                }
             }
         })
         .blur(function () {
             hide_dropdown();
-            $(this).val("");
+            if (settings.showHintAsWatermark) {
+                toggle_watermark(true);
+            } else {
+                $(this).val("");
+            }
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {
@@ -357,6 +367,11 @@ $.TokenList = function (input, url_or_data, settings) {
             letterSpacing: input_box.css("letterSpacing"),
             whiteSpace: "nowrap"
         });
+
+    // Toggle the watermark hint text for the input box if applicable
+    if (settings.showHintAsWatermark) {
+        toggle_watermark(true);
+    }
 
     // Pre-populate list if items exist
     hidden_input.val("");
@@ -646,6 +661,20 @@ $.TokenList = function (input, url_or_data, settings) {
         if(settings.hintText) {
             dropdown.html("<p>"+settings.hintText+"</p>");
             show_dropdown();
+        }
+    }
+
+    // Show or Hide the hint watermark on top of the input field
+    function toggle_watermark (showOrHide) {
+        if (settings.showHintAsWatermark && settings.hintText) {
+            if (showOrHide) {
+                input_box.val(settings.hintText)
+                    .addClass(settings.classes.watermark);
+                resize_input();
+            } else {
+                input_box.val("")
+                    .removeClass(settings.classes.watermark);
+            }
         }
     }
 

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -28,6 +28,10 @@ ul.token-input-list li input {
     -webkit-appearance: caret;
 }
 
+ul.token-input-list li input.token-input-watermark-applied {
+  color: #acacac;
+}
+
 li.token-input-token {
     overflow: hidden; 
     height: auto !important; 


### PR DESCRIPTION
Add option to allow hintText to be a watermark inside the input
box instead of appearing on the dropdown.
When this option is enabled a new class is also added to the input
element to help customize the text styling of the watermark.
This patch also adds a demo of the new functionality to the demo page.

Fixes issue #203 from upstream