### PR TITLE
Allow tokenValue to be a function for more complex use cases

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -460,8 +460,7 @@ $.TokenList = function (input, url_or_data, settings) {
             });
 
         // Store data on the token
-        var token_data = {"id": item.id};
-        token_data[settings.propertyToSearch] = item[settings.propertyToSearch];
+        var token_data = item;
         $.data(this_token.get(0), "tokeninput", item);
 
         // Save this token for duplicate checking
@@ -612,6 +611,9 @@ $.TokenList = function (input, url_or_data, settings) {
     // Update the hidden input box value
     function update_hidden_input(saved_tokens, hidden_input) {
         var token_values = $.map(saved_tokens, function (el) {
+            if(typeof settings.tokenValue == 'function')
+              return settings.tokenValue.call(this, el);
+            
             return el[settings.tokenValue];
         });
         hidden_input.val(token_values.join(settings.tokenDelimiter));


### PR DESCRIPTION
Store the entire item from the server response, not just the name and id. Then allow the tokenValue to be a function that is passed the item, and returns a string. This allows more complex data than just the id to be sent to the server.

I am using this in polymorphic associations in a Rails app, so I need to know both the type and id of the object I am selecting. I send it back to the server in the format "Type|ID,Type|ID..." (pipe separated attributes, comma separated tokens). Then on the server side I can parse out that string and get the behavior I want.
