### PR TITLE
Caching option and onResult on cached results

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -445,5 +445,40 @@
         });
         </script>
     </div>
+	
+	 <h2>No caching Data Search</h2>
+    <div>
+        <input type="text" id="demo-input-nocache" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-nocache").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
+				caching:false
+			});
+        });
+        </script>
+    </div>
+	
+	 <h2>No duplicate suggestion Data Search</h2>
+    <div>
+        <input type="text" id="demo-input-nodupsug" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-nodupsug").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
+                onResult: function (results) {
+					var exists={};
+					$($(this).val().split(",")).each(function(i,val){
+						exists[val]=true;
+					});        
+					
+					return $.grep(results,function(val){
+						return !(exists[val.id]);
+					});
+                }
+            });
+        });
+        </script>
+    </div>
 </body>
 </html>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -19,6 +19,7 @@ var DEFAULT_SETTINGS = {
     propertyToSearch: "name",
     jsonContainer: null,
     contentType: "json",
+	caching: true,
 
 	// Prepopulation settings
     prePopulate: null,
@@ -754,11 +755,20 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Do the actual search
     function run_search(query) {
-        var cache_key = query + computeURL();
-        var cached_results = cache.get(cache_key);
-        if(cached_results) {
-            populate_dropdown(query, cached_results);
-        } else {
+        
+        var found=false;
+        if(settings.caching) {
+			var cache_key = query + computeURL();
+			var cached_results = cache.get(cache_key);
+			if (cached_results) {
+				if($.isFunction(settings.onResult)) {
+                      cached_results = settings.onResult.call(hidden_input, $.extend(true,[],cached_results));
+                }
+				populate_dropdown(query, cached_results);
+				found=true;
+			}
+		}
+		if (!found) {
             // Are we doing an ajax search or local data search?
             if(settings.url) {
                 var url = computeURL();
@@ -788,10 +798,10 @@ $.TokenList = function (input, url_or_data, settings) {
 
                 // Attach the success callback
                 ajax_params.success = function(results) {
+				  settings.caching && cache.add(cache_key, settings.jsonContainer ? results[settings.jsonContainer] : results);
                   if($.isFunction(settings.onResult)) {
-                      results = settings.onResult.call(hidden_input, results);
+                      results = settings.onResult.call(hidden_input, $.extend(true,[],results));
                   }
-                  cache.add(cache_key, settings.jsonContainer ? results[settings.jsonContainer] : results);
 
                   // only populate the dropdown if the results are associated with the active search query
                   if(input_box.val().toLowerCase() === query) {
@@ -802,15 +812,16 @@ $.TokenList = function (input, url_or_data, settings) {
                 // Make the request
                 $.ajax(ajax_params);
             } else if(settings.local_data) {
+				settings.caching && cache.add(cache_key, results);
                 // Do the search through local data
                 var results = $.grep(settings.local_data, function (row) {
                     return row[settings.propertyToSearch].toLowerCase().indexOf(query.toLowerCase()) > -1;
                 });
 
                 if($.isFunction(settings.onResult)) {
-                    results = settings.onResult.call(hidden_input, results);
+                    results = settings.onResult.call(hidden_input, $.extend(true,[],results));
                 }
-                cache.add(cache_key, results);
+                
                 populate_dropdown(query, results);
             }
         }


### PR DESCRIPTION
Targets two request that rose in issue #170

Caching is optional
Always run onResult (on both cached and no cached result list)
Cache only raw responses (do not cache the onResult filtered responses)

Added to demo disabled cache input box
Added to demo filtered result list - suggest only unselected results
