### PR TITLE
Fix results when query contains uppercase characters

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -795,7 +795,7 @@ $.TokenList = function (input, url_or_data, settings) {
                   cache.add(cache_key, settings.jsonContainer ? results[settings.jsonContainer] : results);
 
                   // only populate the dropdown if the results are associated with the active search query
-                  if(input_box.val().toLowerCase() === query) {
+                  if(input_box.val() === query) {
                       populate_dropdown(query, settings.jsonContainer ? results[settings.jsonContainer] : results);
                   }
                 };


### PR DESCRIPTION
As far as I can tell, the master currently doesn't render **any** results when the query contains any uppercase characters. As the commit message says:

```
This was sort-of resolved by loopj/jquery-tokeninput#216, but the query
was still being lowercased in one place, meaning that the results were
not being rendered (!!) when the query contained uppercase chars.
```

It's because at line 806:

```
if(input_box.val().toLowerCase() === query) {
    populate_dropdown(query, settings.jsonContainer ? results[settings.jsonContainer] : results);
}
```

We're expecting `query` to always be lower-case, which as of loopj/jquery-tokeninput@2bac4f2, it's not.
