### PR TITLE
Adding new tokens from the tokenInput interface.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,13 @@ The tokeninput takes an optional second parameter on intitialization which allow
     Prevent user from selecting duplicate values by setting this to `true`. default: ``false`` (demo).
 #### tokenValue
     The value of the token input when the input is submitted. Set it to id in order to get a concatenation of token IDs, or to name in order to get a concatenation of names. default: `id`
-#### allowAddToken
+#### addTokenAllow
 	Allows the user to add tokens to the database from the tokenInput. You must have defined a POST action in the same script you're referencing with `url:` default: `false`
+#### addTokenMethod
+	Specify which HTTP method is used to query the add token endpoint. default: `POST`
+#### addTokenURL
+	Specify which URL endpoint to hit when a new token is submitted. When left blank, the add token action just uses `settings.url`. 
+	default: `""`.  
 
 ### Callbacks
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -12,20 +12,6 @@
 
 
 (function ($) {
-// Default classes to use when theming
-var DEFAULT_CLASSES = {
-    tokenList: "token-input-list",
-    token: "token-input-token",
-    tokenDelete: "token-input-delete-token",
-    selectedToken: "token-input-selected-token",
-    highlightedToken: "token-input-highlighted-token",
-    dropdown: "token-input-dropdown",
-    dropdownItem: "token-input-dropdown-item",
-    dropdownItem2: "token-input-dropdown-item2",
-    selectedDropdownItem: "token-input-selected-dropdown-item",
-    inputToken: "token-input-input-token",
-	addToken: "token-input-add-token"
-};
 
 // Default settings
 var DEFAULT_SETTINGS = {
@@ -71,6 +57,21 @@ var DEFAULT_SETTINGS = {
 
     // Other settings
     idPrefix: "token-input-"
+};
+
+// Default classes to use when theming
+var DEFAULT_CLASSES = {
+    tokenList: "token-input-list",
+    token: "token-input-token",
+    tokenDelete: "token-input-delete-token",
+    selectedToken: "token-input-selected-token",
+    highlightedToken: "token-input-highlighted-token",
+    dropdown: "token-input-dropdown",
+    dropdownItem: "token-input-dropdown-item",
+    dropdownItem2: "token-input-dropdown-item2",
+    selectedDropdownItem: "token-input-selected-dropdown-item",
+    inputToken: "token-input-input-token",
+	addToken: "token-input-add-token"
 };
 
 // Input box position "enum"
@@ -342,7 +343,7 @@ $.TokenList = function (input, url_or_data, settings) {
         .insertBefore(hidden_input);
 
     // The token holding the input box
-    input_token = $("<li />")
+    var input_token = $("<li />")
         .addClass(settings.classes.inputToken)
         .appendTo(token_list)
         .append(input_box);


### PR DESCRIPTION
Tokens can now be added to the database from within tokenInput. To enable this feature, simply set `addTokenAllow: true` and create a POST action in your endpoint for REST compatibility. Otherwise, you can use `addTokenURL` to specify the URL that you want to hit when a user wants to add their newly-created token to the database. If you already use POST for your search query action, you can specify another HTTP method like GET or PUT in its place.

We have deployed this modified version of jquery.tokeninput on a number of live production servers, and it works great. We think it would make a great addition to the plugin!
