### PR TITLE
New config option: z-index

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -31,6 +31,7 @@ var DEFAULT_SETTINGS = {
     deleteText: "&times;",
     animateDropdown: true,
     theme: null,
+    zindex: 999,
     resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
     tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
 
@@ -674,7 +675,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 top: $(token_list).offset().top + $(token_list).outerHeight(),
                 left: $(token_list).offset().left,
                 width: $(token_list).outerWidth(),
-                'z-index': 999
+                'z-index': settings.zindex
             })
             .show();
     }


### PR DESCRIPTION
Added dropdown z-index as a configuration option. Setting it to 100001 allows the dropdown to render correctly inside Twitter's Bootstrap modal dialog (with or without backdrop).
