### PR TITLE
Added ability to enter custom tokens

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.5.1/jquery.min.js"></script>
+    <script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
     <script type="text/javascript" src="src/jquery.tokeninput.js"></script>
 
     <link rel="stylesheet" href="styles/token-input.css" type="text/css" />
@@ -483,6 +483,39 @@
                     {id: 555, name: "Bob Hoskins"},
                     {id: 9000, name: "Kriss Akabusi"}
                 ]
+            });
+        });
+        </script>
+    </div>
+
+    <h2>Alowed to enter new tokens (not only from backend)</h2>
+    <div>
+        <input type="text" id="demo-input-alowed-new" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-alowed-new").tokenInput([{
+                "user_name": "Arthur Godfrey",
+                "email": "arthur_godfrey@nccu.edu",
+                "avatar": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "user_name": "Adam Johnson",
+                "email": "wravo@yahoo.com",
+                "avatar": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            },
+            {
+                "user_name": "Jeff Johnson",
+                "email": "bballnine@hotmail.com",
+                "avatar": "https://si0.twimg.com/sticky/default_profile_images/default_profile_2_normal.png"
+            }], {
+                allowedNewItems: true,
+                propertyToSearch: "user_name",
+                tokenValue: "email",
+                resultsFormatter: function(item){ return "<li>" + "<img src='" + item.avatar + "' title='" + item.user_name + "' height='25px' width='25px' />" + "<div style='display: inline-block; padding-left: 10px;'><div class='full_name'>" + item.user_name + "</div><div class='email'>" + item.email + "</div></div></li>" },
+                tokenFormatter: function(item) { return "<li><p>" + item.user_name + "</p></li>" },
+                hintText: "Type and select users from list or enter email",
+                noResultsText: "users not found"
             });
         });
         </script>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -51,7 +51,10 @@ var DEFAULT_SETTINGS = {
     idPrefix: "token-input-",
 
     // Keep track if the input is currently in disabled mode
-    disabled: false
+    disabled: false,
+
+    // Set to true if you need to enter new tokens (not only from backend)
+    allowedNewItems: false
 };
 
 // Default classes to use when theming
@@ -276,10 +279,15 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.ENTER:
                 case KEY.NUMPAD_ENTER:
                 case KEY.COMMA:
-                  if(selected_dropdown_item) {
+                  if(selected_dropdown_item && $(selected_dropdown_item).data("tokeninput") != undefined) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
                     hidden_input.change();
                     return false;
+                  } else if ($(this).val().length && settings.allowedNewItems) {
+                      token_object = {}
+                      token_object[settings.propertyToSearch] = token_object[settings.tokenValue] = $(this).val()
+                      add_token(token_object);
+                      return false;
                   }
                   break;
 


### PR DESCRIPTION
This feature allows you to add value in manual mode.
For example:
We need to send the message (or invited) to multiple email addresses. In our database we store users, who have email. With standard functionality jQuery Tokeninput, we can choose only the addresses of our users like in sample. But what if we want to add any address to receive the message? By using the alowedNewItems parameter in settings, we can resolve this problem. After set this parameter to true, just simply typing a new email that will be added to the list.
