### PR TITLE
Fix for #49, IE arrow keys strangeness

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -248,8 +248,8 @@ $.TokenList = function (input, url_or_data, settings) {
                         if(dropdown_item.length) {
                             select_dropdown_item(dropdown_item);
                         }
-                        return false;
                     }
+                    return false;
                     break;
 
                 case KEY.BACKSPACE:


### PR DESCRIPTION
Here's a one-line fix that works for me. I gave it a quick test in Chrome/FF/IE (including IE6)/Safari, and saw no adverse effects.

Fixes the issue by taking kuroir's suggestion of preventing
the default action. To be consistent with the rest of the
code, we do this by returning false in the event handler.
