### PR TITLE
Adds setting for default text when token input is empty

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -26,6 +26,7 @@ var DEFAULT_SETTINGS = {
 
     // Display settings
     hintText: "Type in a search term",
+    defaultText: "",
     noResultsText: "No results",
     searchingText: "Searching...",
     deleteText: "&times;",
@@ -202,11 +203,12 @@ $.TokenList = function (input, url_or_data, settings) {
             } else
             if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
                 show_dropdown_hint();
+                hide_default_text();
             }
         })
         .blur(function () {
             hide_dropdown();
-            $(this).val("");
+            show_default_text();
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {
@@ -295,6 +297,10 @@ $.TokenList = function (input, url_or_data, settings) {
                     break;
             }
         });
+    
+    if(settings.defaultText) {
+      input_box.val(settings.defaultText);
+    }
 
     // Keep a reference to the original input box
     var hidden_input = $(input)
@@ -692,6 +698,16 @@ $.TokenList = function (input, url_or_data, settings) {
             dropdown.html("<p>"+settings.hintText+"</p>");
             show_dropdown();
         }
+    }
+    
+    function show_default_text() {
+      if(token_count == 0) {
+        input_box.val(settings.defaultText);
+      }
+    }
+    
+    function hide_default_text() {
+      input_box.val("");
     }
 
     // Highlight the query part of the search term

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -297,10 +297,6 @@ $.TokenList = function (input, url_or_data, settings) {
                     break;
             }
         });
-    
-    if(settings.defaultText) {
-      input_box.val(settings.defaultText);
-    }
 
     // Keep a reference to the original input box
     var hidden_input = $(input)
@@ -387,6 +383,10 @@ $.TokenList = function (input, url_or_data, settings) {
             insert_token(value);
             checkTokenLimit();
         });
+    }
+
+    if(token_count == 0 && settings.defaultText) {
+      input_box.val(settings.defaultText);
     }
 
     // Check if widget should initialize as disabled

--- a/styles/token-input-facebook.css
+++ b/styles/token-input-facebook.css
@@ -22,6 +22,7 @@ ul.token-input-list-facebook li input {
     width: 100px;
     padding: 3px 8px;
     background-color: white;
+    color: #999;
     margin: 2px 0;
     -webkit-appearance: caret;
 }

--- a/styles/token-input-mac.css
+++ b/styles/token-input-mac.css
@@ -109,6 +109,7 @@ li.token-input-input-token-mac input {
   width: 100px;
   padding: 3px;
   background-color: transparent;
+  color: #999;
   margin: 0;
 }
 

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -25,6 +25,7 @@ ul.token-input-list li input {
     width: 350px;
     padding: 3px 8px;
     background-color: white;
+    color: #999;
     -webkit-appearance: caret;
 }
 


### PR DESCRIPTION
I have a number of forms where I keep the "view mode" and "edit mode" roughly the same - disabling inputs instead of replacing them with plain text.

For Token Input, I disable it, and hide it's styling. This is problematic when there are no tokens, as the user, in "view mode", has no indication there's even an element there. If the Token Input represented members in a group, I would like to have default text reading "No members", for instance.

This pull request is a very non-intrusive change which allows a simple default piece of text to exist in the case that the Token Input is empty and unfocused. It is akin to the default text often utilized in websites for input tags, e.g. a light grey "First Name Here..." on an input asking for somebody's first name.
