### PR TITLE
Allow custom entry and avoid parallel ajax calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,12 @@ Features added by TomsLabs
     * when allowCustomEntry setting is true and no token is selected, type enter or tab adds current token
 
   - Avoid parallel search request in order to optimize performance 
+  
+  - Make highlight duplicate switchable (with highlightDuplicates, default to true)
 
 Init example
 ------------
-    $('#inputTokenId').tokenInput('/my/url/', {'allowCustomEntry' : true});
+    $('#inputTokenId').tokenInput('/my/url/', {'allowCustomEntry' : true, 'highlightDuplicates' : false});
 
 
 Demo

--- a/README.md
+++ b/README.md
@@ -12,6 +12,17 @@ Features added by TomsLabs
     * when allowCustomEntry setting is true, type comma allows to add a token that isn't suggested in token list
     * when allowCustomEntry setting is true and no token is selected, type enter or tab adds current token
 
+
+Init example
+------------
+    $('#inputTokenId').tokenInput('/my/url/', {'allowCustomEntry' : true});
+
+
+Demo
+-----
+http://www.tomsguide.fr/solutions/nouveau_sujet.htm (on tag input)
+
+
 Documentation, Features and Demos
 ---------------------------------
 Full details and documentation can be found on the project page here:

--- a/README.md
+++ b/README.md
@@ -5,6 +5,13 @@ Overview
 --------
 Tokeninput is a jQuery plugin which allows your users to select multiple items from a predefined list, using autocompletion as they type to find each item. You may have seen a similar type of text entry when filling in the recipients field sending messages on facebook.
 
+Features added by TomsLabs
+-------------------------
+
+  - Allow custom entry : 
+    * when allowCustomEntry setting is true, type comma allows to add a token that isn't suggested in token list
+    * when allowCustomEntry setting is true and no token is selected, type enter or tab adds current token
+
 Documentation, Features and Demos
 ---------------------------------
 Full details and documentation can be found on the project page here:

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Features added by TomsLabs
     * when allowCustomEntry setting is true, type comma allows to add a token that isn't suggested in token list
     * when allowCustomEntry setting is true and no token is selected, type enter or tab adds current token
 
+  - Avoid parallel search request in order to optimize performance 
 
 Init example
 ------------

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -39,6 +39,7 @@ var DEFAULT_SETTINGS = {
     tokenLimit: null,
     tokenDelimiter: ",",
     preventDuplicates: false,
+    highlightDuplicates: true,
     tokenValue: "id",
 
     // Callbacks
@@ -554,16 +555,19 @@ $.TokenList = function (input, url_or_data, settings) {
             token_list.children().each(function () {
                 var existing_token = $(this);
                 var existing_data = $.data(existing_token.get(0), "tokeninput");
-                if(existing_data && existing_data[settings['tokenValue']] === item[settings['tokenValue']]) {
+
+                if(existing_data && existing_data[settings.tokenValue] === item[settings.tokenValue]) {
                     found_existing_token = existing_token;
                     return false;
                 }
             });
 
             if(found_existing_token) {
-                select_token(found_existing_token);
-                input_token.insertAfter(found_existing_token);
-                focus_with_timeout(input_box);
+                if(settings.highlightDuplicates) {
+                    select_token(found_existing_token);
+                    input_token.insertAfter(found_existing_token);
+                    focus_with_timeout(input_box);
+                }
                 return;
             }
         }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -311,14 +311,14 @@ $.TokenList = function (input, url_or_data, settings) {
       add_token($(selected_dropdown_item).data("tokeninput"));
       hidden_input.change();
       return false;
-    };
+    }
     
     function addCurrentTokenInputValue() {
       var currentTokenInputItem = {"name": $("#" + settings.idPrefix + input.id).val()};
       add_token(currentTokenInputItem);
       hidden_input.change();
       return false;
-    };
+    }
 
     // Keep a reference to the original input box
     var hidden_input = $(input)

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -313,7 +313,7 @@ $.TokenList = function (input, url_or_data, settings) {
     };
     
     function addCurrentTokenInputValue() {
-      var currentTokenInputItem = {"name": $("#token-input-post_tags_labels").val()};
+      var currentTokenInputItem = {"name": $("#" + settings.idPrefix + input.id).val()};
       add_token(currentTokenInputItem);
       hidden_input.change();
       return false;

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -427,11 +427,11 @@ $.TokenList = function (input, url_or_data, settings) {
                 delete_token($(this));
             }
         });
-    }
+    };
 
     this.add = function(item) {
         add_token(item);
-    }
+    };
 
     this.remove = function(item) {
         token_list.children("li").each(function() {
@@ -449,15 +449,15 @@ $.TokenList = function (input, url_or_data, settings) {
                 }
             }
         });
-    }
+    };
 
     this.getTokens = function() {
         return saved_tokens;
-    }
+    };
 
     this.toggleDisabled = function(disable) {
         toggleDisabled(disable);
-    }
+    };
 
     //
     // Private functions

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -51,7 +51,10 @@ var DEFAULT_SETTINGS = {
     idPrefix: "token-input-",
 
     // Keep track if the input is currently in disabled mode
-    disabled: false
+    disabled: false,
+    
+    // Allowed add token which is not in suggest list
+    allowCustomEntry: false
 };
 
 // Default classes to use when theming
@@ -278,6 +281,11 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.COMMA:
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
+                    hidden_input.change();
+                    return false;
+                  } else if (settings.allowCustomEntry)  {
+                    var currentTokenInputItem = {"name": $("#token-input-post_tags_labels").val()};
+                    add_token(currentTokenInputItem);
                     hidden_input.change();
                     return false;
                   }
@@ -749,6 +757,7 @@ $.TokenList = function (input, url_or_data, settings) {
         } else {
             if(settings.noResultsText) {
                 dropdown.html("<p>"+settings.noResultsText+"</p>");
+                selected_dropdown_item = null;
                 show_dropdown();
             }
         }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -314,7 +314,8 @@ $.TokenList = function (input, url_or_data, settings) {
     }
     
     function addCurrentTokenInputValue() {
-      var currentTokenInputItem = {"name": $("#" + settings.idPrefix + input.id).val()};
+      var currentTokenInputItem = new Object();
+      currentTokenInputItem[settings.propertyToSearch] = $("#" + settings.idPrefix + input.id).val();
       add_token(currentTokenInputItem);
       hidden_input.change();
       return false;

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -127,7 +127,7 @@ var methods = {
         this.data("tokenInputObject").toggleDisabled(disable);
         return this;
     }
-}
+};
 
 // Expose the .tokenInput function to jQuery as a plugin
 $.fn.tokenInput = function (method) {

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -554,7 +554,7 @@ $.TokenList = function (input, url_or_data, settings) {
             token_list.children().each(function () {
                 var existing_token = $(this);
                 var existing_data = $.data(existing_token.get(0), "tokeninput");
-                if(existing_data && existing_data.id === item.id) {
+                if(existing_data && existing_data[settings['tokenValue']] === item[settings['tokenValue']]) {
                     found_existing_token = existing_token;
                     return false;
                 }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -20,7 +20,7 @@ var DEFAULT_SETTINGS = {
     jsonContainer: null,
     contentType: "json",
 
-	// Prepopulation settings
+  	// Prepopulation settings
     prePopulate: null,
     processPrePopulate: false,
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -32,8 +32,8 @@ var DEFAULT_SETTINGS = {
     animateDropdown: true,
     theme: null,
     zindex: 999,
-    resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
-    tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
+    resultsFormatter: function(item){return "<li>" + item[this.propertyToSearch]+ "</li>"},
+    tokenFormatter: function(item) {return "<li><p>" + item[this.propertyToSearch] + "</p></li>"},
 
     // Tokenization settings
     tokenLimit: null,
@@ -278,16 +278,18 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.TAB:
                 case KEY.ENTER:
                 case KEY.NUMPAD_ENTER:
-                case KEY.COMMA:
                   if(selected_dropdown_item) {
-                    add_token($(selected_dropdown_item).data("tokeninput"));
-                    hidden_input.change();
-                    return false;
+                    return addSelectedToken();
                   } else if (settings.allowCustomEntry)  {
-                    var currentTokenInputItem = {"name": $("#token-input-post_tags_labels").val()};
-                    add_token(currentTokenInputItem);
-                    hidden_input.change();
-                    return false;
+                    return addCurrentTokenInputValue();
+                  }
+                  break;
+                  
+                case KEY.COMMA:
+                  if (settings.allowCustomEntry)  {
+                    return addCurrentTokenInputValue();
+                  } else if(selected_dropdown_item) {
+                    return addSelectedToken();
                   }
                   break;
 
@@ -303,6 +305,19 @@ $.TokenList = function (input, url_or_data, settings) {
                     break;
             }
         });
+
+    function addSelectedToken() {
+      add_token($(selected_dropdown_item).data("tokeninput"));
+      hidden_input.change();
+      return false;
+    };
+    
+    function addCurrentTokenInputValue() {
+      var currentTokenInputItem = {"name": $("#token-input-post_tags_labels").val()};
+      add_token(currentTokenInputItem);
+      hidden_input.change();
+      return false;
+    };
 
     // Keep a reference to the original input box
     var hidden_input = $(input)
@@ -883,7 +898,7 @@ $.TokenList = function (input, url_or_data, settings) {
     // 
     // obj: a jQuery object to focus()
     function focus_with_timeout(obj) {
-        setTimeout(function() { obj.focus(); }, 50);
+        setTimeout(function() {obj.focus();}, 50);
     }
 
 };

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -821,6 +821,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Do the actual search
     function run_search(query) {
+        var self = this;
         var cache_key = query + computeURL();
         var cached_results = cache.get(cache_key);
         if(cached_results) {
@@ -866,8 +867,12 @@ $.TokenList = function (input, url_or_data, settings) {
                   }
                 };
 
+                if(typeof self.currentSearchRequest !== "undefined") {
+                   self.currentSearchRequest.abort();
+                }
+
                 // Make the request
-                $.ajax(ajax_params);
+                self.currentSearchRequest = $.ajax(ajax_params);
             } else if(settings.local_data) {
                 // Do the search through local data
                 var results = $.grep(settings.local_data, function (row) {


### PR DESCRIPTION
For Tom's Guide and Tom's Hardware specific behaviour, we added a new option that allows custom entries that are not in suggested list.

By default this option is set to false.

When allowCustomEntry setting is true:
    - type comma allows to add a token that isn't suggested in token list
    - and when no token is selected, type enter or tab adds current token

By the way, in order to improve performances and avoid waiting for ajax calls timeout when webservice is too slow, we abort previous running search before launching new one.
## Init example

```
$('#inputTokenId').tokenInput('/my/url/', {'allowCustomEntry' : true});
```
## Demo

http://www.tomsguide.fr/solutions/nouveau_sujet.htm (on tag input)
