### PR TITLE
We have a scenario where we're fetching parameters such as ..&p_request=...

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -815,7 +815,7 @@ $.TokenList = function (input, url_or_data, settings) {
                     var param_array = parts[1].split("&");
                     $.each(param_array, function (index, value) {
                         var kv = value.split("=");
-                        ajax_params.data[kv[0]] = kv[1];
+                        ajax_params.data[kv[0]] = value.substring(parseInt(kv[0].length)+1);
                     });
                 } else {
                     ajax_params.url = url;


### PR DESCRIPTION
...PLUGIN=FOO from the query string. They get parsed and the second part is not appended. I didn't find a way to prevent them. A solution that is compatible to the current may be this little change.
