### PR TITLE
Adding query to the onResult params

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -955,7 +955,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
                 cache.add(cache_key, results);
                 if($.isFunction($(input).data("settings").onResult)) {
-                    results = $(input).data("settings").onResult.call(hidden_input, results);
+                    results = $(input).data("settings").onResult.call(hidden_input, results, query);
                 }
                 populate_dropdown(query, results);
             }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -851,7 +851,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 });
 
                 if($.isFunction(settings.onResult)) {
-                    results = settings.onResult.call(hidden_input, results);
+                    results = settings.onResult.call(hidden_input, results, query);
                 }
                 cache.add(cache_key, results);
                 populate_dropdown(query, results);


### PR DESCRIPTION
Allows the call back access to the query value.  I use it to add the query's value to the results for a "new" token.
