### PR TITLE
I've added placeholder to the settings/options to allow for HTML5 placeholder attribute on input

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -68,6 +68,20 @@
         </script>
     </div>
 
+    
+    <h2>Placeholder</h2>
+    <div>
+        <input type="text" id="demo-input-placeholder" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-placeholder").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
+                placeholder: "Type to search"
+            });
+        });
+        </script>
+    </div>
+
 
     <h2 id="custom-labels">Custom Labels</h2>
     <div>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -29,6 +29,7 @@ var DEFAULT_SETTINGS = {
     noResultsText: "No results",
     searchingText: "Searching...",
     deleteText: "&times;",
+    placeholder: null,
     animateDropdown: true,
     theme: null,
     zindex: 999,
@@ -195,7 +196,10 @@ $.TokenList = function (input, url_or_data, settings) {
         .css({
             outline: "none"
         })
-        .attr("id", settings.idPrefix + input.id)
+        .attr({
+          placeholder: settings.placeholder,
+          id: settings.idPrefix + input.id
+        })
         .focus(function () {
             if (settings.disabled) {
                 return false;
@@ -470,7 +474,8 @@ $.TokenList = function (input, url_or_data, settings) {
         // Enter new content into resizer and resize input accordingly
         var escaped = input_val.replace(/&/g, '&amp;').replace(/\s/g,' ').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         input_resizer.html(escaped);
-        input_box.width(input_resizer.width() + 30);
+        var width = input_box.width();
+        input_box.width(Math.max(width, input_resizer.width() + 30));
     }
 
     function is_printable_character(keycode) {


### PR DESCRIPTION
I had to tweak the resize_input method, so that it would work with placeholder.
Because the input_resizer.width() returned 0, the input became 30px wide, which hides the placeholder.

Also didn't seem to function well with the facebook theme.
