### PR TITLE
Simplify

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -50,6 +50,9 @@ var DEFAULT_SETTINGS = {
     // Other settings
     idPrefix: "token-input-",
 
+    // Backwards compatibility settings
+    maintainHiddenInputValue: true, // slower but backwards compatible
+
     // Keep track if the input is currently in disabled mode
     disabled: false
 };
@@ -118,6 +121,9 @@ var methods = {
     },
     get: function() {
         return this.data("tokenInputObject").getTokens();
+    },
+    val : function() {
+       return this.data("tokenInputObject").val();
     },
     toggleDisabled: function(disable) {
         this.data("tokenInputObject").toggleDisabled(disable);
@@ -367,7 +373,9 @@ $.TokenList = function (input, url_or_data, settings) {
         });
 
     // Pre-populate list if items exist
-    hidden_input.val("");
+    if(settings.maintainHiddenInputValue) {
+        hidden_input.val("");
+    }
     var li_data = settings.prePopulate || hidden_input.data("pre");
     if(settings.processPrePopulate && $.isFunction(settings.onResult)) {
         li_data = settings.onResult.call(hidden_input, li_data);
@@ -425,6 +433,10 @@ $.TokenList = function (input, url_or_data, settings) {
 
     this.getTokens = function() {
         return get_tokens();
+    }
+
+    this.val = function() {
+        return get_token_value_string();
     }
 
     this.toggleDisabled = function(disable) {
@@ -644,16 +656,21 @@ $.TokenList = function (input, url_or_data, settings) {
         }).get();
     }
 
-    // Update the hidden input box value
-    function update_hidden_input(hidden_input) {
+    function get_token_value_string() {
         var token_values = $.map(get_tokens(), function (el) {
             if(typeof settings.tokenValue == 'function')
               return settings.tokenValue.call(this, el);
             
             return el[settings.tokenValue];
         });
-        hidden_input.val(token_values.join(settings.tokenDelimiter));
+        return token_values.join(settings.tokenDelimiter);
+    }
 
+    // Update the hidden input box value
+    function update_hidden_input(hidden_input) {
+        if(settings.maintainHiddenInputValue) {
+            hidden_input.val(get_token_value_string());
+        }
     }
 
     // Hide and clear the results dropdown

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -177,9 +177,6 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
 
-    // Save the tokens
-    var saved_tokens = [];
-
     // Keep track of the number of tokens in the list
     var token_count = 0;
 
@@ -309,7 +306,6 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Keep a reference to the selected token and dropdown item
     var selected_token = null;
-    var selected_token_index = 0;
     var selected_dropdown_item = null;
 
     // The list to store the token items in
@@ -428,7 +424,7 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     this.getTokens = function() {
-        return saved_tokens;
+        return get_tokens();
     }
 
     this.toggleDisabled = function(disable) {
@@ -503,12 +499,7 @@ $.TokenList = function (input, url_or_data, settings) {
         var token_data = item;
         $.data(this_token.get(0), "tokeninput", item);
 
-        // Save this token for duplicate checking
-        saved_tokens = saved_tokens.slice(0,selected_token_index).concat([token_data]).concat(saved_tokens.slice(selected_token_index));
-        selected_token_index++;
-
-        // Update the hidden input
-        update_hidden_input(saved_tokens, hidden_input);
+        update_hidden_input(hidden_input);
 
         token_count += 1;
 
@@ -584,13 +575,10 @@ $.TokenList = function (input, url_or_data, settings) {
 
         if(position === POSITION.BEFORE) {
             input_token.insertBefore(token);
-            selected_token_index--;
         } else if(position === POSITION.AFTER) {
             input_token.insertAfter(token);
-            selected_token_index++;
         } else {
             input_token.appendTo(token_list);
-            selected_token_index = token_count;
         }
 
         // Show the input box and give it focus again
@@ -619,7 +607,6 @@ $.TokenList = function (input, url_or_data, settings) {
         var callback = settings.onDelete;
 
         var index = token.prevAll().length;
-        if(index > selected_token_index) index--;
 
         // Delete the token
         token.remove();
@@ -628,12 +615,8 @@ $.TokenList = function (input, url_or_data, settings) {
         // Show the input box and give it focus again
         focus_with_timeout(input_box);
 
-        // Remove this token from the saved list
-        saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));
-        if(index < selected_token_index) selected_token_index--;
-
         // Update the hidden input
-        update_hidden_input(saved_tokens, hidden_input);
+        update_hidden_input(hidden_input);
 
         token_count -= 1;
 
@@ -650,9 +633,20 @@ $.TokenList = function (input, url_or_data, settings) {
         }
     }
 
+    // returns all the tokens stored in token_list.
+    // (returns the data items, not the dom elements)
+    function get_tokens() {
+        var tokenListItems = token_list.children("li").filter(function(index) {
+            return ($(this).children("input").length == 0);
+        });
+        return tokenListItems.map(function(index, element) {
+            return $(element).data("tokeninput");
+        }).get();
+    }
+
     // Update the hidden input box value
-    function update_hidden_input(saved_tokens, hidden_input) {
-        var token_values = $.map(saved_tokens, function (el) {
+    function update_hidden_input(hidden_input) {
+        var token_values = $.map(get_tokens(), function (el) {
             if(typeof settings.tokenValue == 'function')
               return settings.tokenValue.call(this, el);
             


### PR DESCRIPTION
Curious if you agree that removing the need for hidden state (in particular saved_tokens/selected_token_index) might be a good direction for jquery-tokeninput. My motivations were:
- Fix https://github.com/loopj/jquery-tokeninput/issues/303
- Make the control a little easier to understand/maintain.
- Stay backward compatible

The first commit from this branch (206fbaa503a98bd42d5f40e3c65ba462a8de9912) is the central one. The second (206fbaa5) is a followup in case the first is thought to create performance problems by recalculating the entire hidden_input.val() string each time there's a token operation.

Cheers,
ryguasu
