### PR TITLE
Added `token-input-focused` CSS class to mimic focused state.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -66,6 +66,7 @@ var DEFAULT_CLASSES = {
     dropdownItem2: "token-input-dropdown-item2",
     selectedDropdownItem: "token-input-selected-dropdown-item",
     inputToken: "token-input-input-token",
+    focused: "token-input-focused",
     disabled: "token-input-disabled"
 };
 
@@ -203,10 +204,12 @@ $.TokenList = function (input, url_or_data, settings) {
             if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
                 show_dropdown_hint();
             }
+            token_list.addClass(settings.classes.focused);
         })
         .blur(function () {
             hide_dropdown();
             $(this).val("");
+            token_list.removeClass(settings.classes.focused);
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {


### PR DESCRIPTION
Hello,

I recently wanted to make a Bootstrap theme for your great plugin. The trouble I had was I needed to mimic the focused state of a standard input, so I added the `token-input-focused` class as a workaround.

Best,
