### PR TITLE
Create new tokens setting + bug fix

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -20,7 +20,7 @@ var DEFAULT_SETTINGS = {
     jsonContainer: null,
     contentType: "json",
 
-	// Prepopulation settings
+    // Prepopulation settings
     prePopulate: null,
     processPrePopulate: false,
 
@@ -40,6 +40,7 @@ var DEFAULT_SETTINGS = {
     tokenDelimiter: ",",
     preventDuplicates: false,
     tokenValue: "id",
+    createTokens: false,
 
     // Callbacks
     onResult: null,
@@ -281,6 +282,13 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.COMMA:
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
+                    hidden_input.change();
+                    return false;
+                  } else if (settings.createTokens && $.trim($(this).val()).length > 0) {
+                    var data = {}
+                    data[settings.tokenValue] = '__created';
+                    data[settings.propertyToSearch] = $.trim($(this).val());
+                    add_token(data);
                     hidden_input.change();
                     return false;
                   }
@@ -534,7 +542,12 @@ $.TokenList = function (input, url_or_data, settings) {
             token_list.children().each(function () {
                 var existing_token = $(this);
                 var existing_data = $.data(existing_token.get(0), "tokeninput");
-                if(existing_data && existing_data.id === item.id) {
+                if (settings.createTokens && item[settings.tokenValue] == '__created') {
+                    if (existing_data && existing_data[settings.propertyToSearch] == item[settings.propertyToSearch]) {
+                        found_existing_token = existing_token;
+                        return false;
+                    }
+                } else if(existing_data && existing_data[settings.tokenValue] === item[settings.tokenValue]) {
                     found_existing_token = existing_token;
                     return false;
                 }
@@ -659,6 +672,9 @@ $.TokenList = function (input, url_or_data, settings) {
             if(typeof settings.tokenValue == 'function')
               return settings.tokenValue.call(this, el);
             
+            if (settings.createTokens && el[settings.tokenValue] == "__created") {
+                return "__created:" + el[settings.propertyToSearch];
+            }
             return el[settings.tokenValue];
         });
         hidden_input.val(token_values.join(settings.tokenDelimiter));
@@ -685,6 +701,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
     function show_dropdown_searching () {
         if(settings.searchingText) {
+            selected_dropdown_item = null;
             dropdown.html("<p>"+settings.searchingText+"</p>");
             show_dropdown();
         }
@@ -692,6 +709,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
     function show_dropdown_hint () {
         if(settings.hintText) {
+            selected_dropdown_item = null;
             dropdown.html("<p>"+settings.hintText+"</p>");
             show_dropdown();
         }


### PR DESCRIPTION
`createTokens` setting allows the creation of new token on enter.

The bug fixed was that if you have set `selected_dropdown_item` and then type another character and then quickly press enter you would get an error pointing to the `add_token` function with `item` being undefined.
