### PR TITLE
Adding a "context" setting, to use tokenInput inside floating dialogs.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -35,6 +35,12 @@ var DEFAULT_SETTINGS = {
     resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
     tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
 
+    // Context for the dropdown
+    // context is the element in which the dropdown element will be added, and against which offsets are measured.
+    // Useful for jQuery dialogs, so that the dropdown moves with them
+    // The context element must be position:relative or absolute
+    context: null,
+
     // Tokenization settings
     tokenLimit: null,
     tokenDelimiter: ",",
@@ -355,7 +361,7 @@ $.TokenList = function (input, url_or_data, settings) {
     // The list to store the dropdown items in
     var dropdown = $("<div>")
         .addClass(settings.classes.dropdown)
-        .appendTo("body")
+        .appendTo( settings.context || "body" )
         .hide();
 
     // Magic element to help us resize the text input
@@ -672,11 +678,17 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     function show_dropdown() {
+        var offset = $(token_list).offset();
+        if (settings.context) {
+          var contextOffset = $(settings.context).offset();
+          offset.left -= contextOffset.left; offset.top -= contextOffset.top;
+        }
+
         dropdown
             .css({
                 position: "absolute",
-                top: $(token_list).offset().top + $(token_list).outerHeight(),
-                left: $(token_list).offset().left,
+                top: offset.top + $(token_list).outerHeight(),
+                left: offset.left,
                 width: $(token_list).outerWidth(),
                 'z-index': settings.zindex
             })


### PR DESCRIPTION
When you use a tokenInput control inside a jQuery UI dialog (or something that behaves similarly), there are a few issues with the "dropdown". If you move the dialog around while displaying the dropdown, the dropdown remains in place. Also, it's fairly easy to get to the point where you dismiss the dialog but the dropdown remains visible in the page forever.

To solve this, I added the concept of a "context" element. When it's null, the context is the body. But if it's not null, then the dropdown gets added to that context element, instead of the body, and when showing it, the absolute offsets are calculated against this context, instead of against the page. That way, the dropdown is positioned correctly, follows the context around, and if the context is killed, the dropdown is killed.

A small side effect of that is that your context needs to be positioned (relative/absolute), but that normally happens naturally anyway.

Admittedly, "context" is probably not the clearest name for it, but I believe the concept is solid, and it solved these two problems for me, while being unobtrusive if you don't need it.
