### PR TITLE
Adding a limit to # of results shown

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -733,7 +733,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 })
                 .hide();
 
-            if (results.length > settings.resultsLimit) {
+            if (settings.resultsLimit && results.length > settings.resultsLimit) {
                 results = results.slice(0, settings.resultsLimit);
             }
 


### PR DESCRIPTION
Sometimes the result set returns more results than is practical to show, especially with local data. Adding a `resultsLimit` option to control that
