### PR TITLE
Added resultsLimit in request parameter; Issue #348

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -856,7 +856,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 // Prepare the request
                 
                 if(settings.limitParam && settings.resultsLimit){
-                    ajax_params.data[settings.resultsLimit] = settings.limitParam;
+                    ajax_params.data[settings.limitParam] = settings.resultsLimit;
                 }
                 
                 ajax_params.data[settings.queryParam] = query;


### PR DESCRIPTION
Example:
http://youurl.com/search.php?q=test&limit=20

Therefore possible automatically pass to the limit of results for the query in the database.
