### PR TITLE
Allow adding an "error" property to the entries to pre-populate

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -32,6 +32,7 @@ var DEFAULT_SETTINGS = {
     animateDropdown: true,
     theme: null,
     zindex: 999,
+    tokenWithErrorClass: "with_error",
     resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
     tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
 
@@ -489,6 +490,8 @@ $.TokenList = function (input, url_or_data, settings) {
         this_token = $(this_token)
           .addClass(settings.classes.token)
           .insertBefore(input_token);
+
+        if (item.error) { this_token.addClass(settings.tokenWithErrorClass) };
 
         // The 'delete token' button
         $("<span>" + settings.deleteText + "</span>")


### PR DESCRIPTION
When pre-populating a tokenInput with entries, allow adding an "error" (boolean) property to each entry, in addition to id and "propertyToSearch".

Entries that have the error set to true, are marked with a class (by default "with_error", but overridable through settings).

---

The reason I added this for myself, and I'm proposing the pull request, is for showing a tokenInput after a validation, to be able to mark "some" entries as problematic (in my case, painting them red)

I thought this might be a useful addition.

Thanks!
Daniel
