### PR TITLE
Bug Fixed : Uncaught TypeError: Object [object Object] has no method 'prop' due to lower version of jquery

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -452,13 +452,13 @@ $.TokenList = function (input, url_or_data, settings) {
         } else {
             settings.disabled = !settings.disabled;
         }
-        input_box.prop('disabled', settings.disabled);
+        input_box.attr('disabled', settings.disabled);
         token_list.toggleClass(settings.classes.disabled, settings.disabled);
         // if there is any token selected we deselect it
         if(selected_token) {
             deselect_token($(selected_token), POSITION.END);
         }
-        hidden_input.prop('disabled', settings.disabled);
+        hidden_input.attr('disabled', settings.disabled);
     }
 
     function checkTokenLimit() {


### PR DESCRIPTION
$.attr() is safe because we are using jQuery v1.5.1 for demos. $.prop() was added from jQuery v1.6
