### PR TITLE
Fixes dropdown not being aligned correctly

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -754,7 +754,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 position: "absolute",
                 top: $(token_list).offset().top + $(token_list).outerHeight(),
                 left: $(token_list).offset().left,
-                width: $(token_list).outerWidth(),
+                width: $(token_list).width(),
                 'z-index': $(input).data("settings").zindex
             })
             .show();


### PR DESCRIPTION
Fixes the dropdown rendering larger than the token input field when the token input field has borders. This bug can be seen on the demo page.
