### PR TITLE
Allow TAB out of the field

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -329,6 +329,8 @@ $.TokenList = function (input, url_or_data, settings) {
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
                     hidden_input.change();
+                    event.stopPropagation();
+                    event.preventDefault();
                   }
                   break;
                 case KEY.ENTER:

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -326,6 +326,11 @@ $.TokenList = function (input, url_or_data, settings) {
                     break;
 
                 case KEY.TAB:
+                  if(selected_dropdown_item) {
+                    add_token($(selected_dropdown_item).data("tokeninput"));
+                    hidden_input.change();
+                  }
+                  break;
                 case KEY.ENTER:
                 case KEY.NUMPAD_ENTER:
                 case KEY.COMMA:


### PR DESCRIPTION
When the user hits TAB and nothing is selected, the focus should move to the next focusable element. Currently, once you are in the field you have to mouse click to get out of it. I have fixed it so that if you have something selected and hit TAB the item is selected and focus stays on the field. If nothing is selected, then focus is moved to the next focusable item as expected.
