### PR TITLE
fixed bug in freetagging

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -332,7 +332,7 @@ $.TokenList = function (input, url_or_data, settings) {
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
                     hidden_input.change();
-                  } else {
+                  } else if ($(input).data("settings").allowFreeTagging) {
                     add_freetagging_tokens();
                     event.stopPropagation();
                     event.preventDefault();


### PR DESCRIPTION
Freetagging isn't completely disabled when you set ```allowFreeTagging``` to false. If you press COMMA or ENTER ```allowFreeTagging``` isn't checked. 