### PR TITLE
allowFreeTagging set to false not work should be fix

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -333,7 +333,11 @@ $.TokenList = function (input, url_or_data, settings) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
                     hidden_input.change();
                   } else {
-                    add_freetagging_tokens();
+                    if ($(input).data("settings").allowFreeTagging) {
+                      add_freetagging_tokens();
+                    } else {
+                      $(this).val("");
+                    }
                     event.stopPropagation();
                     event.preventDefault();
                   }


### PR DESCRIPTION
Original allowFreeTagging set to false not work,
when set allowFreeTagging to false, user type a new tag and press COMMA or ENTER ,
the free tag will be added,
this behavior is not "allowFreeTagging : false", should be fix.
