### PR TITLE
deselect first item when freetagging

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -847,6 +847,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 dropdown_ul.show();
             }
         } else {
+            selected_dropdown_item = null;
             if($(input).data("settings").noResultsText) {
                 dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
                 show_dropdown();


### PR DESCRIPTION
I was finding that with allowFreeTagging, when I'd get search results while typing, an item was selected. Even after the results were hidden, an item was still selected, so when pressing TAB or COMMA, the call to add_free_tagging_tokens() was never reached.
https://github.com/loopj/jquery-tokeninput/blob/master/src/jquery.tokeninput.js#L328-344

This patch simply deselects any items when no results are found from a search query so that the add_free_tagging_tokens() call can execute.
