### PR TITLE
"Real free tagging" and "Allowing enter comma when searching"

### DIFF
--- a/examples/php-example.php
+++ b/examples/php-example.php
@@ -14,6 +14,13 @@ $query = sprintf("SELECT id, name from mytable WHERE name LIKE '%%%s%%' ORDER BY
 $arr = array();
 $rs = mysql_query($query);
 
+# If you want to use free tagging, you can add a free object item into result
+# array. You can add this object as the last element of the array
+// $arr[] = array(
+//    "id"=>$freeTaggingTokenValueSign.$key_word,
+//    "name"=$key_word
+// );
+
 # Collect the results
 while($obj = mysql_fetch_object($rs)) {
     $arr[] = $obj;

--- a/examples/php-example.php
+++ b/examples/php-example.php
@@ -17,7 +17,7 @@ $rs = mysql_query($query);
 # If you want to use free tagging, you can add a free object item into result
 # array. You can add this object as the last element of the array
 // $arr[] = array(
-//    "id"=>$freeTaggingTokenValueSign.$key_word,
+//    "id"=>$freeTaggingTokenValueSign.urlencode($key_word),
 //    "name"=$key_word
 // );
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -28,6 +28,7 @@ var DEFAULT_SETTINGS = {
     hintText: "Type in a search term",
     noResultsText: "No results",
     searchingText: "Searching...",
+    freeTaggingText: "Use",
     deleteText: "&times;",
     animateDropdown: true,
     theme: null,
@@ -38,7 +39,11 @@ var DEFAULT_SETTINGS = {
 
     resultsFormatter: function(item) {
       var string = item[this.propertyToSearch];
-      return "<li>" + (this.enableHTML ? string : _escapeHTML(string)) + "</li>";
+      if (this.allowFreeTagging && item[this.tokenValue].indexOf(this.freeTaggingTokenValueSign) != -1) {
+         return "<li><b><i>" + this.freeTaggingText + ' "' + (this.enableHTML ? string : _escapeHTML(string)) + '"</i></b></li>';
+      } else {
+         return "<li>" + (this.enableHTML ? string : _escapeHTML(string)) + "</li>";
+      }
     },
 
     tokenFormatter: function(item) {
@@ -54,6 +59,8 @@ var DEFAULT_SETTINGS = {
 
     // Behavioral settings
     allowFreeTagging: false,
+    allowFreeTaggingComma: true,
+    freeTaggingTokenValueSign: "+++",
 
     // Callbacks
     onResult: null,
@@ -329,17 +336,21 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.ENTER:
                 case KEY.NUMPAD_ENTER:
                 case KEY.COMMA:
-                  if(selected_dropdown_item) {
-                    add_token($(selected_dropdown_item).data("tokeninput"));
-                    hidden_input.change();
-                  } else {
-                    if ($(input).data("settings").allowFreeTagging) {
-                      add_freetagging_tokens();
-                    } else {
-                      $(this).val("");
-                    }
-                    event.stopPropagation();
-                    event.preventDefault();
+                  if (event.keyCode != KEY.COMMA || !($(input).data("settings").allowFreeTagging && $(input).data("settings").allowFreeTaggingComma)) {
+
+                     if(selected_dropdown_item) {
+                       add_token($(selected_dropdown_item).data("tokeninput"));
+                       hidden_input.change();
+                     } else {
+                       if ($(input).data("settings").allowFreeTagging) {
+                          add_freetagging_tokens();
+                       } else {
+                          $(this).val("");
+                       }
+                       event.stopPropagation();
+                       event.preventDefault();
+                     }
+
                   }
                   return false;
 


### PR DESCRIPTION
I."Real" free tagging

When I used the free tagging function, I tried to add a new value that doesn't exist in the database, and found that if I wanted to add a numerical value as a free tagging value, the return value of the list would be confused with other existing ids. Since I didn’t want to add those items into my object table of database, it cannot be solved by using "onFreeTaggingAdd" with the insert id.

My solution is to add a new node at the beginning of the query result, like this: array('id'=>'+++'.urlencode($key_word), 'name'=>$key_word), so when the tokeninput get’s the certain data, it can verify that the data is whether I want to make it "real" free. With the resultsFormatter function, users can choose to use the pure string as an object to use in that field.

It's not necessary, but it can also apply to the tokenFormatter function.

II. Allowing enter comma when searching

Imagine this: If the field is designed for searching a movie, the problem appears when a user wants to search "I, Robot". If only type the character "I", there are too many matched result to select, and the user will discover that the comma key is not allowed to enter as part of the key word.

So I added the new setting option "allowFreeTaggingComma". When allowFreeTagging and allowFreeTaggingComma are both set to true, the user can type a comma sign as part of the key word.
