### PR TITLE
New allowFreeTaggingDuringSearch option

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -56,6 +56,7 @@ var DEFAULT_SETTINGS = {
     // Behavioral settings
     allowFreeTagging: false,
     allowTabOut: false,
+    allowFreeTaggingDuringSearch: true,
 
     // Callbacks
     onResult: null,

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -549,7 +549,6 @@ $.TokenList = function (input, url_or_data, settings) {
     function add_freetagging_tokens() {
         //If allowFreeTaggingDuringSearch option is false and the search is not finished, return from this function
         if (!$.isFunction($(input).data("settings").allowFreeTaggingDuringSearch) && search_in_progress){
-            console.log("non salvo il freetagging");
             return;
         }
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -372,6 +372,9 @@ $.TokenList = function (input, url_or_data, settings) {
     var selected_token_index = 0;
     var selected_dropdown_item = null;
 
+    // Keep the search status logged
+    var search_in_progress = false;
+
     // The list to store the token items in
     var token_list = $("<ul />")
         .addClass($(input).data("settings").classes.tokenList)
@@ -544,6 +547,12 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     function add_freetagging_tokens() {
+        //If allowFreeTaggingDuringSearch option is false and the search is not finished, return from this function
+        if (!$.isFunction($(input).data("settings").allowFreeTaggingDuringSearch) && search_in_progress){
+            console.log("non salvo il freetagging");
+            return;
+        }
+
         var value = $.trim(input_box.val());
         var tokens = value.split($(input).data("settings").tokenDelimiter);
         $.each(tokens, function(i, token) {
@@ -801,6 +810,8 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Populate the results dropdown with some results
     function populate_dropdown (query, results) {
+        search_in_progress = false;
+
         if(results && results.length) {
             dropdown.empty();
             var dropdown_ul = $("<ul>")
@@ -897,6 +908,8 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Do the actual search
     function run_search(query) {
+        search_in_progress = true;
+
         var cache_key = query + computeURL();
         var cached_results = cache.get(cache_key);
         if(cached_results) {


### PR DESCRIPTION
In some case is better stopping the free tagging feature and wait for the search results. This can prevent some wrong or duplicate user values so I've introduced the allowFreeTaggingDuringSearch option (false by default)
