### PR TITLE
fix for jquery 1.8.2 compatibility - dropdown moving to the bottom

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -756,7 +756,7 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: $(token_list).offset().top + $(token_list).outerHeight(),
+                top: $(token_list).offset().top + $(token_list).height(),
                 left: $(token_list).offset().left,
                 width: $(token_list).width(),
                 'z-index': $(input).data("settings").zindex


### PR DESCRIPTION
fix for jquery 1.8.2 token-input-dropdown moved to the bottom as outerHeight is deprecated.
