### PR TITLE
tab out support

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -335,7 +335,11 @@ $.TokenList = function (input, url_or_data, settings) {
                     hidden_input.change();
                   } else {
                     if ($(input).data("settings").allowFreeTagging) {
-                      add_freetagging_tokens();
+                      if($(input).data("settings").allowTabOut && $(this).val() === "") {
+                        return true;
+                      } else {
+                        add_freetagging_tokens();
+                      }
                     } else {
                       $(this).val("");
                       if($(input).data("settings").allowTabOut) {


### PR DESCRIPTION
When no text has been types, it is often the intent of the user to tab out of the input box, rather than attempting to auto complete an empty string. This patch adds the `allowTabOut` option (defaults to false) that when set allows such behavior. It handles both the free tagging case, and the non-free tagging case.
