### PR TITLE
Fixes free tagging when clicking away

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -252,7 +252,6 @@ $.TokenList = function (input, url_or_data, settings) {
         })
         .blur(function () {
             hide_dropdown();
-            $(this).val("");
             token_list.removeClass($(input).data("settings").classes.focused);
 
             if ($(input).data("settings").allowFreeTagging) {


### PR DESCRIPTION
If free tagging was allowed and you would write something and click away from the field the data would be cleared.
