### PR TITLE
Add ability to set placeholder text for text input field

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -29,6 +29,7 @@ var DEFAULT_SETTINGS = {
     noResultsText: "No results",
     searchingText: "Searching...",
     deleteText: "&times;",
+    placeHolderText: '',
     animateDropdown: true,
     theme: null,
     zindex: 999,
@@ -241,7 +242,8 @@ $.TokenList = function (input, url_or_data, settings) {
             outline: "none"
         })
         .attr("id", $(input).data("settings").idPrefix + input.id)
-        .focus(function () {
+        .attr("placeholder", $(input).data("settings").placeHolderText)
+		.focus(function () {
             if ($(input).data("settings").disabled) {
                 return false;
             } else


### PR DESCRIPTION
Credit goes to StackOverflow user xylar for answering this question:
http://stackoverflow.com/questions/12682582/adding-placeholder-text-to-jquery-tokenizer.

User can now set the placeholder text of the text input field using jquery tokenizer.

Example configuration:

```
$(function() {
    $("#account_town").tokenInput("http://example.com/search", {
    'placeHolderText': 'Enter Town...',
});
```
