### PR TITLE
fix bug on ie < 9, this reference

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -376,6 +376,8 @@ $.TokenList = function (input, url_or_data, settings) {
                            })
                            .blur(function () {
                                input_box.blur();
+                               //return the object to this can be referenced in the callback functions.
+                               return hidden_input;
                            });
 
     // Keep a reference to the selected token and dropdown item


### PR DESCRIPTION
solved an ie < 9 bug where you can't reference this as the jquery object where you initialize the plugin in the custom callbacks
