### PR TITLE
Allowing pass arrays in url, just as seen in issue #304

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -947,7 +947,15 @@ $.TokenList = function (input, url_or_data, settings) {
                     var param_array = parts[1].split("&");
                     $.each(param_array, function (index, value) {
                         var kv = value.split("=");
-                        ajax_params.data[kv[0]] = kv[1];
+                        if(kv[0] in ajax_params.data){
+                            if($.isArray(ajax_params.data[kv[0]])){
+                                ajax_params.data[kv[0]].push(kv[1]);
+                            }else{
+                                ajax_params.data[kv[0]] = [ajax_params.data[kv[0]], kv[1]];
+                            }
+                        }else{
+                            ajax_params.data[kv[0]] = kv[1];
+                        }
                     });
                 } else {
                     ajax_params.url = url;


### PR DESCRIPTION
This addition only changes the way how tonkeninput get the parameters from url, allowing him to process arrays, and not the last element of the array, which was the way that was implemented.
