### PR TITLE
using the token list's offset height (border-box height)...

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -783,9 +783,9 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: $(token_list).offset().top + $(token_list).height(),
-                left: $(token_list).offset().left,
-                width: $(token_list).width(),
+                top: token_list.offset().top + token_list[0].getBoundingClientRect().height,
+                left: token_list.offset().left,
+                width: token_list.width(),
                 'z-index': $(input).data("settings").zindex
             })
             .show();


### PR DESCRIPTION
...instead of its content height in determining where to position the dropdown. Also removing some redundant `$(...)` calls.

Note that [.getBoundingClientRect](https://developer.mozilla.org/en-US/docs/DOM/element.getBoundingClientRect) is supported all the way back to IE4, Firefox 3, Safari 4, and in all Chrome and Opera versions.
