### PR TITLE
Add ability to set a default value for free-tagged items

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -54,6 +54,7 @@ var DEFAULT_SETTINGS = {
     tokenValue: "id",
 
     // Behavioral settings
+    defaultValue: -1,
     allowFreeTagging: false,
     allowTabOut: false,
 
@@ -576,7 +577,8 @@ $.TokenList = function (input, url_or_data, settings) {
             token = $(input).data("settings").onFreeTaggingAdd.call(hidden_input, token);
           }
           var object = {};
-          object[$(input).data("settings").tokenValue] = object[$(input).data("settings").propertyToSearch] = token;
+          object[$(input).data("settings").tokenValue] = $(input).data("settings").defaultValue;
+          object[$(input).data("settings").propertyToSearch] = token;
           add_token(object);
         });
     }


### PR DESCRIPTION
Previously, free tagging created the object:
`{ id: "token", name: "token"}`

Now, users can configure a default value for the **id** field when working with free tagged tokens, with
`.tokenInput(data, {defaultValue: -1});
