### PR TITLE
Should deselect any dropdown item if no results

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -888,6 +888,9 @@ $.TokenList = function (input, url_or_data, settings) {
             }
         } else {
             if($(input).data("settings").noResultsText) {
+                if(selected_dropdown_item) {
+                    deselect_dropdown_item($(selected_dropdown_item));
+                }
                 dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
                 show_dropdown();
             }


### PR DESCRIPTION
When populating dropdown, if results are not found, deselect anything that might have been selected previously. Otherwise it sticks around and throws an error if you try to create a new tag with your entry.
