### PR TITLE
remove previously selected items before a new search

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -921,7 +921,11 @@ $.TokenList = function (input, url_or_data, settings) {
             if(selected_token) {
                 deselect_token($(selected_token), POSITION.AFTER);
             }
-
+            
+            if (selected_dropdown_item) {
+                deselect_dropdown_item($(selected_dropdown_item));
+            }
+            
             if(query.length >= $(input).data("settings").minChars) {
                 show_dropdown_searching();
                 clearTimeout(timeout);


### PR DESCRIPTION
deselecting previously selected items resolves the bug described and solved in issue https://github.com/loopj/jquery-tokeninput/issues/430 by @corneliuskopp and https://github.com/loopj/jquery-tokeninput/pull/512 by @meelash
