### PR TITLE
Optional paramters passed in search request query string

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -963,6 +963,15 @@ $.TokenList = function (input, url_or_data, settings) {
                 } else {
                     ajax_params.url = url;
                 }
+				
+				//add params passed in as urlParams
+                if (settings.urlParams != null) {
+                    for (var key in settings.urlParams) {
+                        if (settings.urlParams.hasOwnProperty(key)) {
+                            ajax_params.data[key] = settings.urlParams[key];
+                        }
+                    }
+                }
 
                 // Prepare the request
                 ajax_params.data[$(input).data("settings").queryParam] = query;


### PR DESCRIPTION
When initializing, added the option urlParams which is an object
contaning name,value pairs like {"excludeIDs":getExcludedIDs,"const":1}.
This is added to the search query string. Would result in something like

http://localhost:52854/Admin/searchForSwimmers?excludeIDs=1&const=1&q=luk

The initialzation was:

$("#swimmerAddingDropdown").tokenInput("/Admin/searchForSwimmers", {
urlParams: {"excludeIDs":getCurrentSwimmerList,"const":1},

etc...
