### PR TITLE
appending dropdown to html element instead of body

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -423,7 +423,7 @@ $.TokenList = function (input, url_or_data, settings) {
     // The list to store the dropdown items in
     var dropdown = $("<div>")
         .addClass($(input).data("settings").classes.dropdown)
-        .appendTo("body")
+        .appendTo("html")
         .hide();
 
     // Magic element to help us resize the text input


### PR DESCRIPTION
Some HTML documents do not have a body (e.g. frameset documents).

Appending the dropdown to the html element ensures that it will display even in documents that have no body.
