### PR TITLE
Fix old IE versions bug

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -796,7 +796,7 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: token_list.offset().top + token_list[0].getBoundingClientRect().height,
+                top: token_list.offset().top + token_list.outerHeight(),
                 left: token_list.offset().left,
                 width: token_list.width(),
                 'z-index': $(input).data("settings").zindex


### PR DESCRIPTION
Use `.outerHeight` instead of low-level `.getBoundingClientRect`.
See [comment](https://github.com/loopj/jquery-tokeninput/pull/499#issuecomment-18186838) on #499
