### PR TITLE
appending dropdown to html element if document has no body

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -436,7 +436,7 @@ $.TokenList = function (input, url_or_data, settings) {
     // The list to store the dropdown items in
     var dropdown = $("<div>")
         .addClass($(input).data("settings").classes.dropdown)
-        .appendTo("body")
+        .appendTo($("body")[0] || "html")
         .hide();
 
     // Magic element to help us resize the text input


### PR DESCRIPTION
HTML4 frameset documents don't have a body.

Appending the dropdown to the html element if there is no body ensures that it will display even in these documents. This commit maintains current behavior (appending it to the body) for modern (non-frameset) HTML documents.

This commit is intended to help third-party scripts (e.g. browser extensions), which don't have a choice about whether a document uses a frameset or a body.
