### PR TITLE
Don't cut off placeholder text in the input field.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -562,7 +562,7 @@ $.TokenList = function (input, url_or_data, settings) {
         // Get width left on the current line
         var width_left = token_list.width() - input_box.offset().left - token_list.offset().left;
         // Enter new content into resizer and resize input accordingly
-        input_resizer.html(_escapeHTML(input_val));
+        input_resizer.html(_escapeHTML(input_val) || _escapeHTML(settings.placeholder));
         // Get maximum width, minimum the size of input and maximum the widget's width
         input_box.width(Math.min(token_list.width(),
                                  Math.max(width_left, input_resizer.width() + 30)));


### PR DESCRIPTION
In #resize_input, if there is no input value, resize input to the width of the placeholder text.
