### PR TITLE
Adjust z-index for Bootstrap modals. Don't show display hint when calling clear()

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -598,6 +598,7 @@ $.TokenList = function (input, url_or_data, settings) {
         var readonly = item.readonly === true ? true : false;
 
         if(readonly) $this_token.addClass($(input).data("settings").classes.tokenReadOnly);
+        if(item.class) $this_token.addClass(item.class);
 
         $this_token.addClass($(input).data("settings").classes.token).insertBefore(input_token);
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -32,7 +32,7 @@ var DEFAULT_SETTINGS = {
     animateDropdown: true,
     placeholder: null,
     theme: null,
-    zindex: 999,
+    zindex: 1100,
     resultsLimit: null,
 
     enableHTML: false,

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -506,7 +506,7 @@ $.TokenList = function (input, url_or_data, settings) {
                     }
                 }
                 if (match) {
-                    delete_token($(this));
+                    delete_token($(this), false);
                 }
             }
         });

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -491,7 +491,7 @@ $.TokenList = function (input, url_or_data, settings) {
     };
 
     this.add = function(item) {
-        add_token(item);
+        add_token(item, false);
     };
 
     this.remove = function(item) {
@@ -639,7 +639,11 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     // Add a token to the token list based on user input
-    function add_token (item) {
+    function add_token (item, interactive) {
+        // Differentiates between programtic add_token and user add_token
+        // User actions would need to show the display hint, et all
+        interactive = typeof interactive !== 'undefined' ? interactive : true;
+      
         var callback = $(input).data("settings").onAdd;
 
         // See if the token already exists and select it if we don't want duplicates
@@ -680,7 +684,7 @@ $.TokenList = function (input, url_or_data, settings) {
         hide_dropdown();
 
         // Execute the onAdd callback if defined
-        if($.isFunction(callback)) {
+        if($.isFunction(callback) && interactive) {
             callback.call(hidden_input,item);
         }
     }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -773,8 +773,9 @@ $.TokenList = function (input, url_or_data, settings) {
             focus_with_timeout(input_box);
         }
 
-        // Execute the onDelete callback if defined
-        if($.isFunction(callback)) {
+        // Execute the onDelete callback if defined and this was a user-initiated delete
+        // (as opposed to a programmatic 'clear' or 'remove' call)
+        if($.isFunction(callback) && interactive) {
             callback.call(hidden_input,token_data);
         }
     }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -14,8 +14,8 @@ var DEFAULT_SETTINGS = {
     // Search settings
     method: "GET",
     queryParam: "q",
-    searchDelay: 300,
-    minChars: 1,
+    searchDelay: 175,
+    minChars: 3,
     propertyToSearch: "name",
     jsonContainer: null,
     contentType: "json",
@@ -236,6 +236,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Save the tokens
     var saved_tokens = [];
+    var token_values = [];
 
     // Keep track of the number of tokens in the list
     var token_count = 0;
@@ -625,7 +626,7 @@ $.TokenList = function (input, url_or_data, settings) {
         selected_token_index++;
 
         // Update the hidden input
-        update_hidden_input(saved_tokens, hidden_input);
+        hidden_input_insert(hidden_input, token_data);
 
         token_count += 1;
 
@@ -643,7 +644,7 @@ $.TokenList = function (input, url_or_data, settings) {
         // Differentiates between programtic add_token and user add_token
         // User actions would need to show the display hint, et all
         interactive = typeof interactive !== 'undefined' ? interactive : true;
-      
+
         var callback = $(input).data("settings").onAdd;
 
         // See if the token already exists and select it if we don't want duplicates
@@ -743,7 +744,7 @@ $.TokenList = function (input, url_or_data, settings) {
         // Differentiates between programtic delete_token and user delete_token
         // User actions would need to show the display hint, et all
         interactive = typeof interactive !== 'undefined' ? interactive : true;
-        
+
         // Remove the id from the saved list
         var token_data = $.data(token.get(0), "tokeninput");
         var callback = $(input).data("settings").onDelete;
@@ -766,7 +767,7 @@ $.TokenList = function (input, url_or_data, settings) {
         if(index < selected_token_index) selected_token_index--;
 
         // Update the hidden input
-        update_hidden_input(saved_tokens, hidden_input);
+        hidden_input_remove(hidden_input, token_data);
 
         token_count -= 1;
 
@@ -784,16 +785,16 @@ $.TokenList = function (input, url_or_data, settings) {
         }
     }
 
-    // Update the hidden input box value
-    function update_hidden_input(saved_tokens, hidden_input) {
-        var token_values = $.map(saved_tokens, function (el) {
-            if(typeof $(input).data("settings").tokenValue == 'function')
-              return $(input).data("settings").tokenValue.call(this, el);
+    // Update the hidden input box value by adding a single value
+    function hidden_input_insert(hidden_input, token_data) {
+      token_values.push(token_data[$(input).data("settings").tokenValue]);
+      hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
+    }
 
-            return el[$(input).data("settings").tokenValue];
-        });
-        hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
-
+    // Update the hidden input box value by adding a single value
+    function hidden_input_remove(hidden_input, token_data) {
+      token_values.splice(token_values.indexOf(token_data[$(input).data("settings").tokenValue]), 1);
+      hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
     }
 
     // Hide and clear the results dropdown
@@ -1063,4 +1064,3 @@ $.TokenList.Cache = function (options) {
     };
 };
 }(jQuery));
-

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -485,7 +485,7 @@ $.TokenList = function (input, url_or_data, settings) {
     this.clear = function() {
         token_list.children("li").each(function() {
             if ($(this).children("input").length === 0) {
-                delete_token($(this));
+                delete_token($(this), false);
             }
         });
     };
@@ -734,7 +734,11 @@ $.TokenList = function (input, url_or_data, settings) {
     }
 
     // Delete a token from the token list
-    function delete_token (token) {
+    function delete_token (token, interactive) {
+        // Differentiates between programtic delete_token and user delete_token
+        // User actions would need to show the display hint, et all
+        interactive = typeof interactive !== 'undefined' ? interactive : true;
+        
         // Remove the id from the saved list
         var token_data = $.data(token.get(0), "tokeninput");
         var callback = $(input).data("settings").onDelete;
@@ -747,7 +751,7 @@ $.TokenList = function (input, url_or_data, settings) {
         selected_token = null;
 
         // Show the input box and give it focus again
-        focus_with_timeout(input_box);
+        if(interactive) focus_with_timeout(input_box);
 
         // Remove this token from the saved list
         saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));


### PR DESCRIPTION
The z-index setting is too low for Twitter Bootstrap modals, resulting in tokenInput appearing to not work if one should use a tokenInput in a Bootstrap modal.

Separately, calling the clear() function triggers the display hint text to show. As calling the clear() function is done programmatically (in my case, as part of a BackboneJS render function), I do not want to trigger the display hint text. That should only be triggered when the user does something, not when another piece of code does something, in my opinion.
