### PR TITLE
making "destroy" remove only the token list, and not all other siblings of the input

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -171,14 +171,10 @@ var methods = {
     },
     destroy: function () {
         if(this.data("tokenInputObject")){
-            this.data("tokenInputObject").clear();
-            var tmpInput = this;
-            var closest = this.parent();
-            closest.empty();
-            tmpInput.show();
-            closest.append(tmpInput);
-            return tmpInput;
+            this.data("tokenInputObject").destroy();
+            this.removeData("tokenInputObject settings");
         }
+        return this;
     }
 };
 
@@ -382,10 +378,10 @@ $.TokenList = function (input, url_or_data, settings) {
     var hidden_input = $(input)
                            .hide()
                            .val("")
-                           .focus(function () {
+                           .on("focus.tokenInput", function () {
                                focus_with_timeout(input_box);
                            })
-                           .blur(function () {
+                           .on("blur.tokenInput", function () {
                                input_box.blur();
                                //return the object to this can be referenced in the callback functions.
                                return hidden_input;
@@ -518,6 +514,13 @@ $.TokenList = function (input, url_or_data, settings) {
 
     this.toggleDisabled = function(disable) {
         toggleDisabled(disable);
+    };
+
+    this.destroy = function() {
+        this.clear();
+        token_list.remove();
+        dropdown.remove();
+        hidden_input.off(".tokenInput").show();
     };
 
     // Resize input to maximum width so the placeholder can be seen


### PR DESCRIPTION
Also making "destroy" more complete. It now removes the data and event bindings added to the original input during "init".
