### PR TITLE
adding missing parentheses to fix input width calculation

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -573,7 +573,7 @@
           if(input_val === (input_val = input_box.val())) {return;}
 
           // Get width left on the current line
-          var width_left = token_list.width() - input_box.offset().left - token_list.offset().left;
+          var width_left = token_list.width() - (input_box.offset().left - token_list.offset().left);
           // Enter new content into resizer and resize input accordingly
           input_resizer.html(_escapeHTML(input_val) || _escapeHTML(settings.placeholder));
           // Get maximum width, minimum the size of input and maximum the widget's width


### PR DESCRIPTION
The expression for `W2`, the amount of horizontal space available to the inner box in the diagram below, is `W2 = W1 - (L2 - L1)`. Omitting the parentheses is an error.

```
               [          [                        ⟧
                          -------------------------- W2
               ------------------------------------- W1
--------------- L1
-------------------------- L2
               ----------- (L2 - L1)
```
