### PR TITLE
using computed width instead of content width to give users flexibility to change box-sizing

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -798,7 +798,7 @@ $.TokenList = function (input, url_or_data, settings) {
                 position: "absolute",
                 top: token_list.offset().top + token_list.outerHeight(),
                 left: token_list.offset().left,
-                width: token_list.width(),
+                width: token_list.css("width"),
                 'z-index': $(input).data("settings").zindex
             })
             .show();


### PR DESCRIPTION
This commit does not change anything for most users -- those who do not specify box-sizing for the token-list `ul` or who specify `box-sizing: content-box`. It just gives users the flexibility to add left/right padding to the token list `ul` and set `box-sizing: border-box` on it and the dropdown, so that their widths will still match, despite the padding.

Note that `.css("width")` is also [a performance win](http://blog.jquery.com/2012/08/16/jquery-1-8-box-sizing-width-csswidth-and-outerwidth/) over `.width()`.
