### PR TITLE
Don't select first result as default when addFreeTagging enabled

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -301,6 +301,8 @@ $.TokenList = function (input, url_or_data, settings) {
                             select_token($(next_token.get(0)));
                         }
                     } else {
+                    	var dropdown_item = null;
+                    	
                         if(event.keyCode === KEY.DOWN || event.keyCode === KEY.RIGHT) {
             			//If no item select yet, select first in dropdown
         					if(selected_dropdown_item == null){


### PR DESCRIPTION
When freetagging is enabled, and a user wishes to add a free-tag which is a substring of an existing tag, if they leave longer than 'searchDelay' time before hitting enter, the first item from the dropdown is selected to be the token, rather than the free text the user intended.

This change stops the first result being selected by default when freetagging is enabled, and instead stores it to be selected on the first down/right key press. Existing mouseover behaviour is unaffected.
