### PR TITLE
Introduced onSend callback to be able to modifiy jQuery.ajax parameters....

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -985,6 +985,11 @@ $.TokenList = function (input, url_or_data, settings) {
                   }
                 };
 
+                // Provide a beforeSend callback
+                if (settings.onSend) {
+                  settings.onSend(ajax_params);
+                }
+
                 // Make the request
                 $.ajax(ajax_params);
             } else if($(input).data("settings").local_data) {


### PR DESCRIPTION
Hello and thanks for a great lib.

We've been using your tokeninput for some time, but faced a new problem. Depending on what the user searches for we want ti hit different APIs with different query parameters and urls. (If the user starts with # we search by id and otherwise by query). This turned out to be really messy unless there was some kind of hook being able to modify and read the jQuery ajax parameters. So I added a "onSend" hook. I also considered just relying on jQuery's onBeforeSend, but that callback is being call after the data has been mangled into the url which just makes it a lot more hassle for the typical use case. So...would you fancy pulling this commit?
