### PR TITLE
Ensuring that "change" is called every time the hidden input field is updated.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -322,7 +322,6 @@ $.TokenList = function (input, url_or_data, settings) {
                     if(!$(this).val().length) {
                         if(selected_token) {
                             delete_token($(selected_token));
-                            hidden_input.change();
                         } else if(previous_token.length) {
                             select_token($(previous_token.get(0)));
                         }
@@ -342,7 +341,6 @@ $.TokenList = function (input, url_or_data, settings) {
                 case KEY.COMMA:
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
-                    hidden_input.change();
                   } else {
                     if ($(input).data("settings").allowFreeTagging) {
                       if($(input).data("settings").allowTabOut && $(this).val() === "") {
@@ -455,7 +453,7 @@ $.TokenList = function (input, url_or_data, settings) {
         });
 
     // Pre-populate list if items exist
-    hidden_input.val("");
+    hidden_input.val("").change();
     var li_data = $(input).data("settings").prePopulate || hidden_input.data("pre");
     if($(input).data("settings").processPrePopulate && $.isFunction($(input).data("settings").onResult)) {
         li_data = $(input).data("settings").onResult.call(hidden_input, li_data);
@@ -609,7 +607,6 @@ $.TokenList = function (input, url_or_data, settings) {
               .click(function () {
                   if (!$(input).data("settings").disabled) {
                       delete_token($(this).parent());
-                      hidden_input.change();
                       return false;
                   }
               });
@@ -782,7 +779,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
             return el[$(input).data("settings").tokenValue];
         });
-        hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
+        hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter)).change();
 
     }
 
@@ -850,7 +847,6 @@ $.TokenList = function (input, url_or_data, settings) {
                 })
                 .mousedown(function (event) {
                     add_token($(event.target).closest("li").data("tokeninput"));
-                    hidden_input.change();
                     return false;
                 })
                 .hide();


### PR DESCRIPTION
This change ensures that a change event directly follows each call to $.fn.val on hidden_input. This allows the control to be used cleanly with frameworks that bind form fields to JavaScript objects, such as Knockout.
