### PR TITLE
Add option to control whether first result is automatically selected (including demo)

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -235,9 +235,9 @@
 
     <h2 id="plugin-methods">Using the add, remove, clear and toggleDisabled Methods</h2>
     <div>
-      <a href="#" id="plugin-methods-add">Add Token</a> | 
-      <a href="#" id="plugin-methods-remove">Remove Token</a> | 
-      <a href="#" id="plugin-methods-clear">Clear Tokens</a> | 
+      <a href="#" id="plugin-methods-add">Add Token</a> |
+      <a href="#" id="plugin-methods-remove">Remove Token</a> |
+      <a href="#" id="plugin-methods-clear">Clear Tokens</a> |
       <a href="#" id="plugin-methods-toggle-disable">Toggle Disabled</a><br />
         <input type="text" id="demo-input-plugin-methods" name="blah" />
         <input type="button" value="Submit" />
@@ -272,7 +272,7 @@
         });
         </script>
     </div>
-    
+
     <h2>Local Data Search with custom propertyToSearch, resultsFormatter and tokenFormatter</h2>
     <div>
         <input type="text" id="demo-input-local-custom-formatters" name="blah" />
@@ -674,7 +674,7 @@
         });
         </script>
     </div>
-    
+
     <h2>Start disabled</h2>
     <div>
         <input type="text" id="demo-input-disabled" name="blah" />
@@ -715,6 +715,20 @@
         $(document).ready(function() {
             $("#demo-input-free-tagging").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
                 allowFreeTagging: true
+            });
+        });
+        </script>
+    </div>
+
+    <h2>Free Tagging, automatic selection of first result disabled</h2>
+    <div>
+        <input type="text" id="demo-input-free-tagging-no-autoselect" name="blah" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-free-tagging-no-autoselect").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
+                allowFreeTagging: true,
+                autoSelectFirstResult: false
             });
         });
         </script>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -56,6 +56,7 @@ var DEFAULT_SETTINGS = {
     // Behavioral settings
     allowFreeTagging: false,
     allowTabOut: false,
+    autoSelectFirstResult: true,
 
     // Callbacks
     onResult: null,
@@ -304,9 +305,9 @@ $.TokenList = function (input, url_or_data, settings) {
                         var dropdown_item = null;
 
                         if(event.keyCode === KEY.DOWN || event.keyCode === KEY.RIGHT) {
-                            dropdown_item = $(selected_dropdown_item).next();
+                            dropdown_item = (selected_dropdown_item) ? $(selected_dropdown_item).next() : $(dropdown).find('li').first();
                         } else {
-                            dropdown_item = $(selected_dropdown_item).prev();
+                            dropdown_item = (selected_dropdown_item) ? $(selected_dropdown_item).prev() : $(dropdown).find('li').last();
                         }
 
                         if(dropdown_item.length) {
@@ -872,7 +873,7 @@ $.TokenList = function (input, url_or_data, settings) {
                     this_li.addClass($(input).data("settings").classes.dropdownItem2);
                 }
 
-                if(index === 0) {
+                if((index === 0) && $(input).data("settings").autoSelectFirstResult) {
                     select_dropdown_item(this_li);
                 }
 


### PR DESCRIPTION
Currently, the first result in the drop down is automatically selected. This makes free free tagging difficult because it defaults to that value even if the user intended to enter just a substring of that result.

This commit adds an `autoSelectFirstResult` option which allows to disable that behavior. If it is set to false (the default value is set to true to not break backwards compatibility), the first result won't be automatically selected. Instead, the user has to select it himself.
