### PR TITLE
#336: added option to group tokens

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -68,6 +68,21 @@
         </script>
     </div>
 
+    <h2 id="groups">Group alphabetically</h2>
+    <div>
+        <input type="text" id="demo-input-group" name="blah2" />
+        <input type="button" value="Submit" />
+        <script type="text/javascript">
+        $(document).ready(function() {
+            $("#demo-input-group").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
+                onResult: function(result) { result.sort(function (a, b) { return a.name > b.name; }); return result; },
+                itemGrouper: function (item) { item.group = item.name[0]; return item; }
+            });
+        });
+        </script>
+    </div>
+
+
 
     <h2 id="custom-labels">Custom Labels</h2>
     <div>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -34,6 +34,8 @@ var DEFAULT_SETTINGS = {
     theme: null,
     zindex: 999,
     resultsLimit: null,
+    itemGrouper: null,
+    groupKey: "group",
 
     enableHTML: false,
 
@@ -86,7 +88,8 @@ var DEFAULT_CLASSES = {
     selectedDropdownItem: "token-input-selected-dropdown-item",
     inputToken: "token-input-input-token",
     focused: "token-input-focused",
-    disabled: "token-input-disabled"
+    disabled: "token-input-disabled",
+    itemGroup: "token-input-group"
 };
 
 // Input box position "enum"
@@ -849,8 +852,11 @@ $.TokenList = function (input, url_or_data, settings) {
                     select_dropdown_item($(event.target).closest("li"));
                 })
                 .mousedown(function (event) {
-                    add_token($(event.target).closest("li").data("tokeninput"));
-                    hidden_input.change();
+                    var item = $(event.target).closest("li").data("tokeninput");
+                    if (item) {
+                        add_token(item);
+                        hidden_input.change();
+                    }
                     return false;
                 })
                 .hide();
@@ -859,7 +865,24 @@ $.TokenList = function (input, url_or_data, settings) {
                 results = results.slice(0, $(input).data("settings").resultsLimit);
             }
 
+            var current_group = null;
+
             $.each(results, function(index, value) {
+
+                if ($(input).data("settings").itemGrouper) {
+                    value = $(input).data("settings").itemGrouper(value);
+                }
+                var item_group = value[$(input).data("settings").groupKey];
+                if (item_group && item_group != current_group) {
+                    dropdown_ul.append($("<lh />")
+                        .text(item_group)
+                        .addClass(
+                            $(input).data("settings").classes.itemGroup
+                        )
+                    );
+                    current_group = item_group;
+                }
+
                 var this_li = $(input).data("settings").resultsFormatter(value);
 
                 this_li = find_value_and_highlight_term(this_li ,value[$(input).data("settings").propertyToSearch], query);

--- a/styles/token-input-facebook.css
+++ b/styles/token-input-facebook.css
@@ -103,6 +103,14 @@ div.token-input-dropdown-facebook ul li {
     list-style-type: none;
 }
 
+div.token-input-dropdown-facebook ul lh.token-input-group-facebook {
+    background-color: #f2f2f2;
+    border-top: 1px solid #e2e2e2;
+    border-bottom: none;
+    font-weight: bold;
+    padding: 2px 15px 2px 6px;
+}
+
 div.token-input-dropdown-facebook ul li.token-input-dropdown-item-facebook {
     background-color: #fff;
 }

--- a/styles/token-input.css
+++ b/styles/token-input.css
@@ -125,3 +125,11 @@ div.token-input-dropdown ul li em {
 div.token-input-dropdown ul li.token-input-selected-dropdown-item {
     background-color: #d0efa0;
 }
+
+div.token-input-dropdown ul lh.token-input-group {
+    background-color: #f2f2f2;
+    border-top: 1px solid #e2e2e2;
+    border-bottom: none;
+    font-weight: bold;
+    padding: 2px 15px 2px 6px;
+}


### PR DESCRIPTION
Hi,

This is related to #336. I've added two options: `groupKey` and `itemGrouper`:

`groupKey` is key in the token which will be used to group items by (default: 'group')

`itemGrouper` is a callable that can be used to group items if the group needs to be computed (default: null)

Also added a demo showing how to group results alphabetically.

Results will need to be sorted to avoid duplicate groups.

Thanks.
