### PR TITLE
Handle additionnal data (not only id and name)

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -56,6 +56,12 @@ var DEFAULT_SETTINGS = {
     // Behavioral settings
     allowFreeTagging: false,
     allowTabOut: false,
+    
+    // Data storage
+    returnAsJson: false,
+    dataFilter: function(item) {
+        return item;
+    },
 
     // Callbacks
     onResult: null,
@@ -777,12 +783,20 @@ $.TokenList = function (input, url_or_data, settings) {
     // Update the hidden input box value
     function update_hidden_input(saved_tokens, hidden_input) {
         var token_values = $.map(saved_tokens, function (el) {
-            if(typeof $(input).data("settings").tokenValue == 'function')
-              return $(input).data("settings").tokenValue.call(this, el);
-
-            return el[$(input).data("settings").tokenValue];
+            if(typeof $(input).data("settings").dataFilter == 'function') {
+                el = $(input).data("settings").dataFilter.call(this, el);
+            }
+            if (true === $(input).data("settings").returnAsJson) {
+                return el;
+            } else {
+                return el[$(input).data("settings").tokenValue];
+            }
         });
-        hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
+        if (true === $(input).data("settings").returnAsJson) {
+            hidden_input.val(JSON.stringify(token_values));
+        } else {
+            hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
+        }
 
     }
 


### PR DESCRIPTION
If data provided by the query contains more than just an id and a name, we might want to collect them on form submition.

Example :

``` json
{
    "id": 12,
    "name": "Alabama",
    "country_code": "US"
}
```

With this commit, the option `returnAsJson`, if `true`, makes the form submit the full objects in a json string, instead of juste ids between separators. Example :

``` json
[{"id": 12, "name": "Alabama", "country_code": "US"},{"id": 16, "name": "Alberta", "country_code": "CA"}]
```

instead of

```
12,16
```

Optionnaly, new callback `dataFilter` allows data transformation on client side.
