### PR TITLE
Fixing error when free tagging

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -888,6 +888,7 @@ $.TokenList = function (input, url_or_data, settings) {
             }
         } else {
             if($(input).data("settings").noResultsText) {
+                selected_dropdown_item = null;
                 dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
                 show_dropdown();
             }

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -887,8 +887,8 @@ $.TokenList = function (input, url_or_data, settings) {
                 dropdown_ul.show();
             }
         } else {
+            selected_dropdown_item = null;
             if($(input).data("settings").noResultsText) {
-                selected_dropdown_item = null;
                 dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
                 show_dropdown();
             }


### PR DESCRIPTION
There is a bug when you use `allowFreeTagging`.

Reproduce steps:
1. Use the demo page in version 1.6.1 and scroll to "Free Tagging" at the bottom
2. Start typing something that will match a search (ex: 'a')
3. Pause to let run_search() get called and populate the drop-down
4. Continue typing to a point where it no longer matches an item in the drop-down (ex: 'abc')
5. Hit enter
6. Notice that the item doesn't get populated in the window

What's happening is `selected_dropdown_item` get's set during the `run_search()` -> `populate_dropdown()` -> `selected_dropdown_item()` sequence where it matched a search item when you first started typing. The problem is `selected_dropdown_item` never gets cleared when you continue typing after it no longer matches any items in the dropdown. This breaks the code in the keydown callback. It incorrectly thinks there is a `selected_dropdown_item` (line 343) instead of falling into the else statement that checks for `allowFreeTagging` (line 347).
