### PR TITLE
resolve query string issue

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -952,13 +952,21 @@ $.TokenList = function (input, url_or_data, settings) {
                 var ajax_params = {};
                 ajax_params.data = {};
                 if(url.indexOf("?") > -1) {
+                    var array;
                     var parts = url.split("?");
                     ajax_params.url = parts[0];
 
                     var param_array = parts[1].split("&");
                     $.each(param_array, function (index, value) {
                         var kv = value.split("=");
-                        ajax_params.data[kv[0]] = kv[1];
+                        if((/[a-z][A-Z]?\[\]/).test(kv[0])) {
+                            array = (ajax_params.data.hasOwnProperty(kv[0]) == true) ?
+                              ajax_params.data[kv[0]] : []
+                            array.push(kv[1]);
+                            ajax_params.data[kv[0]] = array;
+                        }
+                        else
+                            ajax_params.data[kv[0]] = kv[1];
                     });
                 } else {
                     ajax_params.url = url;


### PR DESCRIPTION
What I am trying to do is:

Ideally when we pass an array via query string, the controller receives the params with the key pairing with array.

For example:
I have a url like '/controller/action?ids[]=1&ids[]=2&ids[]=3'
Controller will receive as { ids: [1,2,3] }

So when I try to pass same url ('/controller/action?ids[]=1&ids[]=2&ids[]=3') into the token-input search-url, it forms as: '/controller/action?ids[]=3'. If we observe this, the latest value in an array overrides the existing elements.

On debugging, I came across to this code:

if(url.indexOf("?") > -1) {
   var parts = url.split("?");
   ajax_params.url = parts[0];
   var param_array = parts[1].split("&");
   $.each(param_array, function (index, value) {
         var kv = value.split("=");
         ajax_params.data[kv[0]] = kv[1];
   });
} else {
    ajax_params.url = url;
}

As per this snippet, the array elements are overriden by the last element instead of pushing the elements into an array.

The question is what if I wanted to send an array in a query string that is passed to search-url to tokeninput ?

Regarding above concerns, I have modified the code a bit for run_search().
Will you please look at these changes ?

One question:
May i know why are we manipulating parameters in URL ? Is that required ?

Thanks.
