### PR TITLE
Add ability to provide ajaxHeader(s) in config.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -1,6 +1,6 @@
 /*
  * jQuery Plugin: Tokenizing Autocomplete Text Entry
- * Version 1.6.1
+ * Version 1.6.0
  *
  * Copyright (c) 2009 James Smith (http://loopj.com)
  * Licensed jointly under the GPL and MIT licenses,
@@ -11,72 +11,53 @@
 (function ($) {
 // Default settings
 var DEFAULT_SETTINGS = {
-    // Search settings
+	// Search settings
     method: "GET",
+    contentType: "json",
     queryParam: "q",
     searchDelay: 300,
     minChars: 1,
     propertyToSearch: "name",
     jsonContainer: null,
-    contentType: "json",
+    ajaxHeaders: null,
 
-    // Prepopulation settings
-    prePopulate: null,
-    processPrePopulate: false,
-
-    // Display settings
+	// Display settings
     hintText: "Type in a search term",
     noResultsText: "No results",
     searchingText: "Searching...",
     deleteText: "&times;",
     animateDropdown: true,
-    placeholder: null,
-    theme: null,
-    zindex: 999,
-    resultsLimit: null,
 
-    enableHTML: false,
-
-    resultsFormatter: function(item) {
-      var string = item[this.propertyToSearch];
-      return "<li>" + (this.enableHTML ? string : _escapeHTML(string)) + "</li>";
-    },
-
-    tokenFormatter: function(item) {
-      var string = item[this.propertyToSearch];
-      return "<li><p>" + (this.enableHTML ? string : _escapeHTML(string)) + "</p></li>";
-    },
-
-    // Tokenization settings
+	// Tokenization settings
     tokenLimit: null,
     tokenDelimiter: ",",
     preventDuplicates: false,
+
+	// Output settings
     tokenValue: "id",
 
-    // Behavioral settings
-    allowFreeTagging: false,
-    allowTabOut: false,
+	// Prepopulation settings
+    prePopulate: null,
+    processPrePopulate: false,
 
-    // Callbacks
-    onResult: null,
-    onCachedResult: null,
-    onAdd: null,
-    onFreeTaggingAdd: null,
-    onDelete: null,
-    onReady: null,
-
-    // Other settings
+	// Manipulation settings
     idPrefix: "token-input-",
 
-    // Keep track if the input is currently in disabled mode
-    disabled: false
+	// Formatters
+    resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
+    tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
+
+	// Callbacks
+    onResult: null,
+    onAdd: null,
+    onDelete: null,
+    onReady: null
 };
 
 // Default classes to use when theming
 var DEFAULT_CLASSES = {
     tokenList: "token-input-list",
     token: "token-input-token",
-    tokenReadOnly: "token-input-token-readonly",
     tokenDelete: "token-input-delete-token",
     selectedToken: "token-input-selected-token",
     highlightedToken: "token-input-highlighted-token",
@@ -84,9 +65,7 @@ var DEFAULT_CLASSES = {
     dropdownItem: "token-input-dropdown-item",
     dropdownItem2: "token-input-dropdown-item2",
     selectedDropdownItem: "token-input-selected-dropdown-item",
-    inputToken: "token-input-input-token",
-    focused: "token-input-focused",
-    disabled: "token-input-disabled"
+    inputToken: "token-input-input-token"
 };
 
 // Input box position "enum"
@@ -115,34 +94,12 @@ var KEY = {
     COMMA: 188
 };
 
-var HTML_ESCAPES = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#x27;',
-  '/': '&#x2F;'
-};
-
-var HTML_ESCAPE_CHARS = /[&<>"'\/]/g;
-
-function coerceToString(val) {
-  return String((val === null || val === undefined) ? '' : val);
-}
-
-function _escapeHTML(text) {
-  return coerceToString(text).replace(HTML_ESCAPE_CHARS, function(match) {
-    return HTML_ESCAPES[match];
-  });
-}
-
 // Additional public (exposed) methods
 var methods = {
     init: function(url_or_data_or_function, options) {
         var settings = $.extend({}, DEFAULT_SETTINGS, options || {});
 
         return this.each(function () {
-            $(this).data("settings", settings);
             $(this).data("tokenInputObject", new $.TokenList(this, url_or_data_or_function, settings));
         });
     },
@@ -159,28 +116,9 @@ var methods = {
         return this;
     },
     get: function() {
-        return this.data("tokenInputObject").getTokens();
-    },
-    toggleDisabled: function(disable) {
-        this.data("tokenInputObject").toggleDisabled(disable);
-        return this;
-    },
-    setOptions: function(options){
-        $(this).data("settings", $.extend({}, $(this).data("settings"), options || {}));
-        return this;
-    },
-    destroy: function () {
-        if(this.data("tokenInputObject")){
-            this.data("tokenInputObject").clear();
-            var tmpInput = this;
-            var closest = this.parent();
-            closest.empty();
-            tmpInput.show();
-            closest.append(tmpInput);
-            return tmpInput;
-        }
-    }
-};
+    	return this.data("tokenInputObject").getTokens();
+   	}
+}
 
 // Expose the .tokenInput function to jQuery as a plugin
 $.fn.tokenInput = function (method) {
@@ -201,36 +139,36 @@ $.TokenList = function (input, url_or_data, settings) {
     // Configure the data source
     if($.type(url_or_data) === "string" || $.type(url_or_data) === "function") {
         // Set the url to query against
-        $(input).data("settings").url = url_or_data;
+        settings.url = url_or_data;
 
         // If the URL is a function, evaluate it here to do our initalization work
         var url = computeURL();
 
         // Make a smart guess about cross-domain if it wasn't explicitly specified
-        if($(input).data("settings").crossDomain === undefined && typeof url === "string") {
+        if(settings.crossDomain === undefined) {
             if(url.indexOf("://") === -1) {
-                $(input).data("settings").crossDomain = false;
+                settings.crossDomain = false;
             } else {
-                $(input).data("settings").crossDomain = (location.href.split(/\/+/g)[1] !== url.split(/\/+/g)[1]);
+                settings.crossDomain = (location.href.split(/\/+/g)[1] !== url.split(/\/+/g)[1]);
             }
         }
     } else if(typeof(url_or_data) === "object") {
         // Set the local data to search through
-        $(input).data("settings").local_data = url_or_data;
+        settings.local_data = url_or_data;
     }
 
     // Build class names
-    if($(input).data("settings").classes) {
+    if(settings.classes) {
         // Use custom class names
-        $(input).data("settings").classes = $.extend({}, DEFAULT_CLASSES, $(input).data("settings").classes);
-    } else if($(input).data("settings").theme) {
+        settings.classes = $.extend({}, DEFAULT_CLASSES, settings.classes);
+    } else if(settings.theme) {
         // Use theme-suffixed default class names
-        $(input).data("settings").classes = {};
+        settings.classes = {};
         $.each(DEFAULT_CLASSES, function(key, value) {
-            $(input).data("settings").classes[key] = value + "-" + $(input).data("settings").theme;
+            settings.classes[key] = value + "-" + settings.theme;
         });
     } else {
-        $(input).data("settings").classes = DEFAULT_CLASSES;
+        settings.classes = DEFAULT_CLASSES;
     }
 
 
@@ -248,29 +186,19 @@ $.TokenList = function (input, url_or_data, settings) {
     var input_val;
 
     // Create a new text input an attach keyup events
-    var input_box = $("<input type=\"text\"  autocomplete=\"off\" autocapitalize=\"off\">")
+    var input_box = $("<input type=\"text\"  autocomplete=\"off\">")
         .css({
             outline: "none"
         })
-        .attr("id", $(input).data("settings").idPrefix + input.id)
+        .attr("id", settings.idPrefix + input.id)
         .focus(function () {
-            if ($(input).data("settings").disabled) {
-                return false;
-            } else
-            if ($(input).data("settings").tokenLimit === null || $(input).data("settings").tokenLimit !== token_count) {
+            if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
                 show_dropdown_hint();
             }
-            token_list.addClass($(input).data("settings").classes.focused);
         })
         .blur(function () {
             hide_dropdown();
-
-            if ($(input).data("settings").allowFreeTagging) {
-              add_freetagging_tokens();
-            }
-
             $(this).val("");
-            token_list.removeClass($(input).data("settings").classes.focused);
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {
@@ -312,8 +240,8 @@ $.TokenList = function (input, url_or_data, settings) {
                         if(dropdown_item.length) {
                             select_dropdown_item(dropdown_item);
                         }
+                        return false;
                     }
-                    return false;
                     break;
 
                 case KEY.BACKSPACE:
@@ -343,23 +271,9 @@ $.TokenList = function (input, url_or_data, settings) {
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
                     hidden_input.change();
-                  } else {
-                    if ($(input).data("settings").allowFreeTagging) {
-                      if($(input).data("settings").allowTabOut && $(this).val() === "") {
-                        return true;
-                      } else {
-                        add_freetagging_tokens();
-                      }
-                    } else {
-                      $(this).val("");
-                      if($(input).data("settings").allowTabOut) {
-                        return true;
-                      }
-                    }
-                    event.stopPropagation();
-                    event.preventDefault();
+                    return false;
                   }
-                  return false;
+                  break;
 
                 case KEY.ESCAPE:
                   hide_dropdown();
@@ -374,21 +288,15 @@ $.TokenList = function (input, url_or_data, settings) {
             }
         });
 
-    // Keep reference for placeholder
-    if (settings.placeholder)
-        input_box.attr("placeholder", settings.placeholder)
-
     // Keep a reference to the original input box
     var hidden_input = $(input)
                            .hide()
                            .val("")
                            .focus(function () {
-                               focus_with_timeout(input_box);
+                               input_box.focus();
                            })
                            .blur(function () {
                                input_box.blur();
-                               //return the object to this can be referenced in the callback functions.
-                               return hidden_input;
                            });
 
     // Keep a reference to the selected token and dropdown item
@@ -398,7 +306,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // The list to store the token items in
     var token_list = $("<ul />")
-        .addClass($(input).data("settings").classes.tokenList)
+        .addClass(settings.classes.tokenList)
         .click(function (event) {
             var li = $(event.target).closest("li");
             if(li && li.get(0) && $.data(li.get(0), "tokeninput")) {
@@ -410,32 +318,32 @@ $.TokenList = function (input, url_or_data, settings) {
                 }
 
                 // Focus input box
-                focus_with_timeout(input_box);
+                input_box.focus();
             }
         })
         .mouseover(function (event) {
             var li = $(event.target).closest("li");
             if(li && selected_token !== this) {
-                li.addClass($(input).data("settings").classes.highlightedToken);
+                li.addClass(settings.classes.highlightedToken);
             }
         })
         .mouseout(function (event) {
             var li = $(event.target).closest("li");
             if(li && selected_token !== this) {
-                li.removeClass($(input).data("settings").classes.highlightedToken);
+                li.removeClass(settings.classes.highlightedToken);
             }
         })
         .insertBefore(hidden_input);
 
     // The token holding the input box
     var input_token = $("<li />")
-        .addClass($(input).data("settings").classes.inputToken)
+        .addClass(settings.classes.inputToken)
         .appendTo(token_list)
         .append(input_box);
 
     // The list to store the dropdown items in
     var dropdown = $("<div>")
-        .addClass($(input).data("settings").classes.dropdown)
+        .addClass(settings.classes.dropdown)
         .appendTo("body")
         .hide();
 
@@ -456,26 +364,20 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Pre-populate list if items exist
     hidden_input.val("");
-    var li_data = $(input).data("settings").prePopulate || hidden_input.data("pre");
-    if($(input).data("settings").processPrePopulate && $.isFunction($(input).data("settings").onResult)) {
-        li_data = $(input).data("settings").onResult.call(hidden_input, li_data);
+    var li_data = settings.prePopulate || hidden_input.data("pre");
+    if(settings.processPrePopulate && $.isFunction(settings.onResult)) {
+        li_data = settings.onResult.call(hidden_input, li_data);
     }
     if(li_data && li_data.length) {
         $.each(li_data, function (index, value) {
             insert_token(value);
             checkTokenLimit();
-            input_box.attr("placeholder", null)
         });
     }
 
-    // Check if widget should initialize as disabled
-    if ($(input).data("settings").disabled) {
-        toggleDisabled(true);
-    }
-
     // Initialization is done
-    if($.isFunction($(input).data("settings").onReady)) {
-        $(input).data("settings").onReady.call();
+    if($.isFunction(settings.onReady)) {
+        settings.onReady.call();
     }
 
     //
@@ -488,11 +390,11 @@ $.TokenList = function (input, url_or_data, settings) {
                 delete_token($(this));
             }
         });
-    };
+    }
 
     this.add = function(item) {
         add_token(item);
-    };
+    }
 
     this.remove = function(item) {
         token_list.children("li").each(function() {
@@ -510,46 +412,18 @@ $.TokenList = function (input, url_or_data, settings) {
                 }
             }
         });
-    };
-
+    }
+    
     this.getTokens = function() {
-        return saved_tokens;
-    };
-
-    this.toggleDisabled = function(disable) {
-        toggleDisabled(disable);
-    };
-
-    // Resize input to maximum width so the placeholder can be seen
-    resize_input();
+   		return saved_tokens;
+   	}
 
     //
     // Private functions
     //
 
-    function escapeHTML(text) {
-      return $(input).data("settings").enableHTML ? text : _escapeHTML(text);
-    }
-
-    // Toggles the widget between enabled and disabled state, or according
-    // to the [disable] parameter.
-    function toggleDisabled(disable) {
-        if (typeof disable === 'boolean') {
-            $(input).data("settings").disabled = disable
-        } else {
-            $(input).data("settings").disabled = !$(input).data("settings").disabled;
-        }
-        input_box.attr('disabled', $(input).data("settings").disabled);
-        token_list.toggleClass($(input).data("settings").classes.disabled, $(input).data("settings").disabled);
-        // if there is any token selected we deselect it
-        if(selected_token) {
-            deselect_token($(selected_token), POSITION.END);
-        }
-        hidden_input.attr('disabled', $(input).data("settings").disabled);
-    }
-
     function checkTokenLimit() {
-        if($(input).data("settings").tokenLimit !== null && token_count >= $(input).data("settings").tokenLimit) {
+        if(settings.tokenLimit !== null && token_count >= settings.tokenLimit) {
             input_box.hide();
             hide_dropdown();
             return;
@@ -559,13 +433,10 @@ $.TokenList = function (input, url_or_data, settings) {
     function resize_input() {
         if(input_val === (input_val = input_box.val())) {return;}
 
-        // Get width left on the current line
-        var width_left = token_list.width() - input_box.offset().left - token_list.offset().left;
         // Enter new content into resizer and resize input accordingly
-        input_resizer.html(_escapeHTML(input_val) || _escapeHTML(settings.placeholder));
-        // Get maximum width, minimum the size of input and maximum the widget's width
-        input_box.width(Math.min(token_list.width(),
-                                 Math.max(width_left, input_resizer.width() + 30)));
+        var escaped = input_val.replace(/&/g, '&amp;').replace(/\s/g,' ').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+        input_resizer.html(escaped);
+        input_box.width(input_resizer.width() + 30);
     }
 
     function is_printable_character(keycode) {
@@ -575,49 +446,28 @@ $.TokenList = function (input, url_or_data, settings) {
                 (keycode >= 219 && keycode <= 222));    // ( \ ) '
     }
 
-    function add_freetagging_tokens() {
-        var value = $.trim(input_box.val());
-        var tokens = value.split($(input).data("settings").tokenDelimiter);
-        $.each(tokens, function(i, token) {
-          if (!token) {
-            return;
-          }
-
-          if ($.isFunction($(input).data("settings").onFreeTaggingAdd)) {
-            token = $(input).data("settings").onFreeTaggingAdd.call(hidden_input, token);
-          }
-          var object = {};
-          object[$(input).data("settings").tokenValue] = object[$(input).data("settings").propertyToSearch] = token;
-          add_token(object);
-        });
-    }
-
     // Inner function to a token to the list
     function insert_token(item) {
-        var $this_token = $($(input).data("settings").tokenFormatter(item));
-        var readonly = item.readonly === true ? true : false;
-
-        if(readonly) $this_token.addClass($(input).data("settings").classes.tokenReadOnly);
-
-        $this_token.addClass($(input).data("settings").classes.token).insertBefore(input_token);
+        var this_token = settings.tokenFormatter(item);
+        this_token = $(this_token)
+          .addClass(settings.classes.token)
+          .insertBefore(input_token);
 
         // The 'delete token' button
-        if(!readonly) {
-          $("<span>" + $(input).data("settings").deleteText + "</span>")
-              .addClass($(input).data("settings").classes.tokenDelete)
-              .appendTo($this_token)
-              .click(function () {
-                  if (!$(input).data("settings").disabled) {
-                      delete_token($(this).parent());
-                      hidden_input.change();
-                      return false;
-                  }
-              });
-        }
+        $("<span>" + settings.deleteText + "</span>")
+            .addClass(settings.classes.tokenDelete)
+            .appendTo(this_token)
+            .click(function () {
+                delete_token($(this).parent());
+                hidden_input.change();
+                return false;
+            });
 
         // Store data on the token
-        var token_data = item;
-        $.data($this_token.get(0), "tokeninput", item);
+        var token_data = { };
+        token_data[settings.tokenValue] = item[settings.tokenValue];
+        token_data[settings.propertyToSearch] = item[settings.propertyToSearch];
+        $.data(this_token.get(0), "tokeninput", item);
 
         // Save this token for duplicate checking
         saved_tokens = saved_tokens.slice(0,selected_token_index).concat([token_data]).concat(saved_tokens.slice(selected_token_index));
@@ -629,20 +479,20 @@ $.TokenList = function (input, url_or_data, settings) {
         token_count += 1;
 
         // Check the token limit
-        if($(input).data("settings").tokenLimit !== null && token_count >= $(input).data("settings").tokenLimit) {
+        if(settings.tokenLimit !== null && token_count >= settings.tokenLimit) {
             input_box.hide();
             hide_dropdown();
         }
 
-        return $this_token;
+        return this_token;
     }
 
     // Add a token to the token list based on user input
     function add_token (item) {
-        var callback = $(input).data("settings").onAdd;
+        var callback = settings.onAdd;
 
         // See if the token already exists and select it if we don't want duplicates
-        if(token_count > 0 && $(input).data("settings").preventDuplicates) {
+        if(token_count > 0 && settings.preventDuplicates) {
             var found_existing_token = null;
             token_list.children().each(function () {
                 var existing_token = $(this);
@@ -656,19 +506,14 @@ $.TokenList = function (input, url_or_data, settings) {
             if(found_existing_token) {
                 select_token(found_existing_token);
                 input_token.insertAfter(found_existing_token);
-                focus_with_timeout(input_box);
+                input_box.focus();
                 return;
             }
         }
 
-        // Squeeze input_box so we force no unnecessary line break
-        input_box.width(0);
-
         // Insert the new tokens
-        if($(input).data("settings").tokenLimit == null || token_count < $(input).data("settings").tokenLimit) {
+        if(settings.tokenLimit == null || token_count < settings.tokenLimit) {
             insert_token(item);
-            // Remove the placeholder so it's not seen after you've added a token
-            input_box.attr("placeholder", null)
             checkTokenLimit();
         }
 
@@ -686,21 +531,19 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Select a token in the token list
     function select_token (token) {
-        if (!$(input).data("settings").disabled) {
-            token.addClass($(input).data("settings").classes.selectedToken);
-            selected_token = token.get(0);
+        token.addClass(settings.classes.selectedToken);
+        selected_token = token.get(0);
 
-            // Hide input box
-            input_box.val("");
+        // Hide input box
+        input_box.val("");
 
-            // Hide dropdown if it is visible (eg if we clicked to select token)
-            hide_dropdown();
-        }
+        // Hide dropdown if it is visible (eg if we clicked to select token)
+        hide_dropdown();
     }
 
     // Deselect a token in the token list
     function deselect_token (token, position) {
-        token.removeClass($(input).data("settings").classes.selectedToken);
+        token.removeClass(settings.classes.selectedToken);
         selected_token = null;
 
         if(position === POSITION.BEFORE) {
@@ -715,7 +558,7 @@ $.TokenList = function (input, url_or_data, settings) {
         }
 
         // Show the input box and give it focus again
-        focus_with_timeout(input_box);
+        input_box.focus();
     }
 
     // Toggle selection of a token in the token list
@@ -737,7 +580,7 @@ $.TokenList = function (input, url_or_data, settings) {
     function delete_token (token) {
         // Remove the id from the saved list
         var token_data = $.data(token.get(0), "tokeninput");
-        var callback = $(input).data("settings").onDelete;
+        var callback = settings.onDelete;
 
         var index = token.prevAll().length;
         if(index > selected_token_index) index--;
@@ -747,13 +590,10 @@ $.TokenList = function (input, url_or_data, settings) {
         selected_token = null;
 
         // Show the input box and give it focus again
-        focus_with_timeout(input_box);
+        input_box.focus();
 
         // Remove this token from the saved list
         saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));
-        if (saved_tokens.length == 0) {
-            input_box.attr("placeholder", settings.placeholder)
-        }
         if(index < selected_token_index) selected_token_index--;
 
         // Update the hidden input
@@ -761,11 +601,11 @@ $.TokenList = function (input, url_or_data, settings) {
 
         token_count -= 1;
 
-        if($(input).data("settings").tokenLimit !== null) {
+        if(settings.tokenLimit !== null) {
             input_box
                 .show()
-                .val("");
-            focus_with_timeout(input_box);
+                .val("")
+                .focus();
         }
 
         // Execute the onDelete callback if defined
@@ -777,12 +617,9 @@ $.TokenList = function (input, url_or_data, settings) {
     // Update the hidden input box value
     function update_hidden_input(saved_tokens, hidden_input) {
         var token_values = $.map(saved_tokens, function (el) {
-            if(typeof $(input).data("settings").tokenValue == 'function')
-              return $(input).data("settings").tokenValue.call(this, el);
-
-            return el[$(input).data("settings").tokenValue];
+            return el[settings.tokenValue];
         });
-        hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
+        hidden_input.val(token_values.join(settings.tokenDelimiter));
 
     }
 
@@ -796,47 +633,34 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: token_list.offset().top + token_list.outerHeight(),
-                left: token_list.offset().left,
-                width: token_list.width(),
-                'z-index': $(input).data("settings").zindex
+                top: $(token_list).offset().top + $(token_list).outerHeight(),
+                left: $(token_list).offset().left,
+                zindex: 999
             })
             .show();
     }
 
     function show_dropdown_searching () {
-        if($(input).data("settings").searchingText) {
-            dropdown.html("<p>" + escapeHTML($(input).data("settings").searchingText) + "</p>");
+        if(settings.searchingText) {
+            dropdown.html("<p>"+settings.searchingText+"</p>");
             show_dropdown();
         }
     }
 
     function show_dropdown_hint () {
-        if($(input).data("settings").hintText) {
-            dropdown.html("<p>" + escapeHTML($(input).data("settings").hintText) + "</p>");
+        if(settings.hintText) {
+            dropdown.html("<p>"+settings.hintText+"</p>");
             show_dropdown();
         }
     }
 
-    var regexp_special_chars = new RegExp('[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\-]', 'g');
-    function regexp_escape(term) {
-        return term.replace(regexp_special_chars, '\\$&');
-    }
-
     // Highlight the query part of the search term
     function highlight_term(value, term) {
-        return value.replace(
-          new RegExp(
-            "(?![^&;]+;)(?!<[^<>]*)(" + regexp_escape(term) + ")(?![^<>]*>)(?![^&;]+;)",
-            "gi"
-          ), function(match, p1) {
-            return "<b>" + escapeHTML(p1) + "</b>";
-          }
-        );
+        return value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + term + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<b>$1</b>");
     }
-
+    
     function find_value_and_highlight_term(template, value, term) {
-        return template.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + regexp_escape(value) + ")(?![^<>]*>)(?![^&;]+;)", "g"), highlight_term(value, term));
+        return template.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + value + ")(?![^<>]*>)(?![^&;]+;)", "g"), highlight_term(value, term));
     }
 
     // Populate the results dropdown with some results
@@ -855,21 +679,17 @@ $.TokenList = function (input, url_or_data, settings) {
                 })
                 .hide();
 
-            if ($(input).data("settings").resultsLimit && results.length > $(input).data("settings").resultsLimit) {
-                results = results.slice(0, $(input).data("settings").resultsLimit);
-            }
-
             $.each(results, function(index, value) {
-                var this_li = $(input).data("settings").resultsFormatter(value);
-
-                this_li = find_value_and_highlight_term(this_li ,value[$(input).data("settings").propertyToSearch], query);
-
+                var this_li = settings.resultsFormatter(value);
+                
+                this_li = find_value_and_highlight_term(this_li ,value[settings.propertyToSearch], query);            
+                
                 this_li = $(this_li).appendTo(dropdown_ul);
-
+                
                 if(index % 2) {
-                    this_li.addClass($(input).data("settings").classes.dropdownItem);
+                    this_li.addClass(settings.classes.dropdownItem);
                 } else {
-                    this_li.addClass($(input).data("settings").classes.dropdownItem2);
+                    this_li.addClass(settings.classes.dropdownItem2);
                 }
 
                 if(index === 0) {
@@ -881,14 +701,14 @@ $.TokenList = function (input, url_or_data, settings) {
 
             show_dropdown();
 
-            if($(input).data("settings").animateDropdown) {
+            if(settings.animateDropdown) {
                 dropdown_ul.slideDown("fast");
             } else {
                 dropdown_ul.show();
             }
         } else {
-            if($(input).data("settings").noResultsText) {
-                dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
+            if(settings.noResultsText) {
+                dropdown.html("<p>"+settings.noResultsText+"</p>");
                 show_dropdown();
             }
         }
@@ -901,34 +721,34 @@ $.TokenList = function (input, url_or_data, settings) {
                 deselect_dropdown_item($(selected_dropdown_item));
             }
 
-            item.addClass($(input).data("settings").classes.selectedDropdownItem);
+            item.addClass(settings.classes.selectedDropdownItem);
             selected_dropdown_item = item.get(0);
         }
     }
 
     // Remove highlighting from an item in the results dropdown
     function deselect_dropdown_item (item) {
-        item.removeClass($(input).data("settings").classes.selectedDropdownItem);
+        item.removeClass(settings.classes.selectedDropdownItem);
         selected_dropdown_item = null;
     }
 
     // Do a search and show the "searching" dropdown if the input is longer
-    // than $(input).data("settings").minChars
+    // than settings.minChars
     function do_search() {
-        var query = input_box.val();
+        var query = input_box.val().toLowerCase();
 
         if(query && query.length) {
             if(selected_token) {
                 deselect_token($(selected_token), POSITION.AFTER);
             }
 
-            if(query.length >= $(input).data("settings").minChars) {
+            if(query.length >= settings.minChars) {
                 show_dropdown_searching();
                 clearTimeout(timeout);
 
                 timeout = setTimeout(function(){
                     run_search(query);
-                }, $(input).data("settings").searchDelay);
+                }, settings.searchDelay);
             } else {
                 hide_dropdown();
             }
@@ -940,13 +760,10 @@ $.TokenList = function (input, url_or_data, settings) {
         var cache_key = query + computeURL();
         var cached_results = cache.get(cache_key);
         if(cached_results) {
-            if ($.isFunction($(input).data("settings").onCachedResult)) {
-              cached_results = $(input).data("settings").onCachedResult.call(hidden_input, cached_results);
-            }
             populate_dropdown(query, cached_results);
         } else {
             // Are we doing an ajax search or local data search?
-            if($(input).data("settings").url) {
+            if(settings.url) {
                 var url = computeURL();
                 // Extract exisiting get params
                 var ajax_params = {};
@@ -965,43 +782,39 @@ $.TokenList = function (input, url_or_data, settings) {
                 }
 
                 // Prepare the request
-                ajax_params.data[$(input).data("settings").queryParam] = query;
-                ajax_params.type = $(input).data("settings").method;
-                ajax_params.dataType = $(input).data("settings").contentType;
-                if($(input).data("settings").crossDomain) {
+                ajax_params.headers = settings.ajaxHeaders;
+                ajax_params.data[settings.queryParam] = query;
+                ajax_params.type = settings.method;
+                ajax_params.dataType = settings.contentType;
+                if(settings.crossDomain) {
                     ajax_params.dataType = "jsonp";
                 }
 
                 // Attach the success callback
                 ajax_params.success = function(results) {
-                  cache.add(cache_key, $(input).data("settings").jsonContainer ? results[$(input).data("settings").jsonContainer] : results);
-                  if($.isFunction($(input).data("settings").onResult)) {
-                      results = $(input).data("settings").onResult.call(hidden_input, results);
+                  if($.isFunction(settings.onResult)) {
+                      results = settings.onResult.call(hidden_input, results);
                   }
+                  cache.add(cache_key, settings.jsonContainer ? results[settings.jsonContainer] : results);
 
                   // only populate the dropdown if the results are associated with the active search query
-                  if(input_box.val() === query) {
-                      populate_dropdown(query, $(input).data("settings").jsonContainer ? results[$(input).data("settings").jsonContainer] : results);
+                  if(input_box.val().toLowerCase() === query) {
+                      populate_dropdown(query, settings.jsonContainer ? results[settings.jsonContainer] : results);
                   }
                 };
 
-                // Provide a beforeSend callback
-                if (settings.onSend) {
-                  settings.onSend(ajax_params);
-                }
-
                 // Make the request
                 $.ajax(ajax_params);
-            } else if($(input).data("settings").local_data) {
+            } else if(settings.local_data) {
                 // Do the search through local data
-                var results = $.grep($(input).data("settings").local_data, function (row) {
-                    return row[$(input).data("settings").propertyToSearch].toLowerCase().indexOf(query.toLowerCase()) > -1;
+                var results = $.grep(settings.local_data, function (row) {
+                    return row[settings.propertyToSearch].toLowerCase().indexOf(query.toLowerCase()) > -1;
                 });
 
-                cache.add(cache_key, results);
-                if($.isFunction($(input).data("settings").onResult)) {
-                    results = $(input).data("settings").onResult.call(hidden_input, results);
+                if($.isFunction(settings.onResult)) {
+                    results = settings.onResult.call(hidden_input, results);
                 }
+                cache.add(cache_key, results);
                 populate_dropdown(query, results);
             }
         }
@@ -1009,22 +822,12 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // compute the dynamic URL
     function computeURL() {
-        var url = $(input).data("settings").url;
-        if(typeof $(input).data("settings").url == 'function') {
-            url = $(input).data("settings").url.call($(input).data("settings"));
+        var url = settings.url;
+        if(typeof settings.url == 'function') {
+            url = settings.url.call();
         }
         return url;
     }
-
-    // Bring browser focus to the specified object.
-    // Use of setTimeout is to get around an IE bug.
-    // (See, e.g., http://stackoverflow.com/questions/2600186/focus-doesnt-work-in-ie)
-    //
-    // obj: a jQuery object to focus()
-    function focus_with_timeout(obj) {
-        setTimeout(function() { obj.focus(); }, 50);
-    }
-
 };
 
 // Really basic cache for the results

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -1,6 +1,6 @@
 /*
  * jQuery Plugin: Tokenizing Autocomplete Text Entry
- * Version 1.6.0
+ * Version 1.6.1
  *
  * Copyright (c) 2009 James Smith (http://loopj.com)
  * Licensed jointly under the GPL and MIT licenses,
@@ -11,53 +11,73 @@
 (function ($) {
 // Default settings
 var DEFAULT_SETTINGS = {
-	// Search settings
+    // Search settings
     method: "GET",
-    contentType: "json",
     queryParam: "q",
     searchDelay: 300,
     minChars: 1,
     propertyToSearch: "name",
     jsonContainer: null,
+    contentType: "json",
     ajaxHeaders: null,
 
-	// Display settings
+    // Prepopulation settings
+    prePopulate: null,
+    processPrePopulate: false,
+
+    // Display settings
     hintText: "Type in a search term",
     noResultsText: "No results",
     searchingText: "Searching...",
     deleteText: "&times;",
     animateDropdown: true,
+    placeholder: null,
+    theme: null,
+    zindex: 999,
+    resultsLimit: null,
 
-	// Tokenization settings
+    enableHTML: false,
+
+    resultsFormatter: function(item) {
+      var string = item[this.propertyToSearch];
+      return "<li>" + (this.enableHTML ? string : _escapeHTML(string)) + "</li>";
+    },
+
+    tokenFormatter: function(item) {
+      var string = item[this.propertyToSearch];
+      return "<li><p>" + (this.enableHTML ? string : _escapeHTML(string)) + "</p></li>";
+    },
+
+    // Tokenization settings
     tokenLimit: null,
     tokenDelimiter: ",",
     preventDuplicates: false,
-
-	// Output settings
     tokenValue: "id",
 
-	// Prepopulation settings
-    prePopulate: null,
-    processPrePopulate: false,
+    // Behavioral settings
+    allowFreeTagging: false,
+    allowTabOut: false,
 
-	// Manipulation settings
+    // Callbacks
+    onResult: null,
+    onCachedResult: null,
+    onAdd: null,
+    onFreeTaggingAdd: null,
+    onDelete: null,
+    onReady: null,
+
+    // Other settings
     idPrefix: "token-input-",
 
-	// Formatters
-    resultsFormatter: function(item){ return "<li>" + item[this.propertyToSearch]+ "</li>" },
-    tokenFormatter: function(item) { return "<li><p>" + item[this.propertyToSearch] + "</p></li>" },
-
-	// Callbacks
-    onResult: null,
-    onAdd: null,
-    onDelete: null,
-    onReady: null
+    // Keep track if the input is currently in disabled mode
+    disabled: false
 };
 
 // Default classes to use when theming
 var DEFAULT_CLASSES = {
     tokenList: "token-input-list",
     token: "token-input-token",
+    tokenReadOnly: "token-input-token-readonly",
     tokenDelete: "token-input-delete-token",
     selectedToken: "token-input-selected-token",
     highlightedToken: "token-input-highlighted-token",
@@ -65,7 +85,9 @@ var DEFAULT_CLASSES = {
     dropdownItem: "token-input-dropdown-item",
     dropdownItem2: "token-input-dropdown-item2",
     selectedDropdownItem: "token-input-selected-dropdown-item",
-    inputToken: "token-input-input-token"
+    inputToken: "token-input-input-token",
+    focused: "token-input-focused",
+    disabled: "token-input-disabled"
 };
 
 // Input box position "enum"
@@ -94,12 +116,34 @@ var KEY = {
     COMMA: 188
 };
 
+var HTML_ESCAPES = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#x27;',
+  '/': '&#x2F;'
+};
+
+var HTML_ESCAPE_CHARS = /[&<>"'\/]/g;
+
+function coerceToString(val) {
+  return String((val === null || val === undefined) ? '' : val);
+}
+
+function _escapeHTML(text) {
+  return coerceToString(text).replace(HTML_ESCAPE_CHARS, function(match) {
+    return HTML_ESCAPES[match];
+  });
+}
+
 // Additional public (exposed) methods
 var methods = {
     init: function(url_or_data_or_function, options) {
         var settings = $.extend({}, DEFAULT_SETTINGS, options || {});
 
         return this.each(function () {
+            $(this).data("settings", settings);
             $(this).data("tokenInputObject", new $.TokenList(this, url_or_data_or_function, settings));
         });
     },
@@ -116,9 +160,28 @@ var methods = {
         return this;
     },
     get: function() {
-    	return this.data("tokenInputObject").getTokens();
-   	}
-}
+        return this.data("tokenInputObject").getTokens();
+    },
+    toggleDisabled: function(disable) {
+        this.data("tokenInputObject").toggleDisabled(disable);
+        return this;
+    },
+    setOptions: function(options){
+        $(this).data("settings", $.extend({}, $(this).data("settings"), options || {}));
+        return this;
+    },
+    destroy: function () {
+        if(this.data("tokenInputObject")){
+            this.data("tokenInputObject").clear();
+            var tmpInput = this;
+            var closest = this.parent();
+            closest.empty();
+            tmpInput.show();
+            closest.append(tmpInput);
+            return tmpInput;
+        }
+    }
+};
 
 // Expose the .tokenInput function to jQuery as a plugin
 $.fn.tokenInput = function (method) {
@@ -139,36 +202,36 @@ $.TokenList = function (input, url_or_data, settings) {
     // Configure the data source
     if($.type(url_or_data) === "string" || $.type(url_or_data) === "function") {
         // Set the url to query against
-        settings.url = url_or_data;
+        $(input).data("settings").url = url_or_data;
 
         // If the URL is a function, evaluate it here to do our initalization work
         var url = computeURL();
 
         // Make a smart guess about cross-domain if it wasn't explicitly specified
-        if(settings.crossDomain === undefined) {
+        if($(input).data("settings").crossDomain === undefined && typeof url === "string") {
             if(url.indexOf("://") === -1) {
-                settings.crossDomain = false;
+                $(input).data("settings").crossDomain = false;
             } else {
-                settings.crossDomain = (location.href.split(/\/+/g)[1] !== url.split(/\/+/g)[1]);
+                $(input).data("settings").crossDomain = (location.href.split(/\/+/g)[1] !== url.split(/\/+/g)[1]);
             }
         }
     } else if(typeof(url_or_data) === "object") {
         // Set the local data to search through
-        settings.local_data = url_or_data;
+        $(input).data("settings").local_data = url_or_data;
     }
 
     // Build class names
-    if(settings.classes) {
+    if($(input).data("settings").classes) {
         // Use custom class names
-        settings.classes = $.extend({}, DEFAULT_CLASSES, settings.classes);
-    } else if(settings.theme) {
+        $(input).data("settings").classes = $.extend({}, DEFAULT_CLASSES, $(input).data("settings").classes);
+    } else if($(input).data("settings").theme) {
         // Use theme-suffixed default class names
-        settings.classes = {};
+        $(input).data("settings").classes = {};
         $.each(DEFAULT_CLASSES, function(key, value) {
-            settings.classes[key] = value + "-" + settings.theme;
+            $(input).data("settings").classes[key] = value + "-" + $(input).data("settings").theme;
         });
     } else {
-        settings.classes = DEFAULT_CLASSES;
+        $(input).data("settings").classes = DEFAULT_CLASSES;
     }
 
 
@@ -186,19 +249,29 @@ $.TokenList = function (input, url_or_data, settings) {
     var input_val;
 
     // Create a new text input an attach keyup events
-    var input_box = $("<input type=\"text\"  autocomplete=\"off\">")
+    var input_box = $("<input type=\"text\"  autocomplete=\"off\" autocapitalize=\"off\">")
         .css({
             outline: "none"
         })
-        .attr("id", settings.idPrefix + input.id)
+        .attr("id", $(input).data("settings").idPrefix + input.id)
         .focus(function () {
-            if (settings.tokenLimit === null || settings.tokenLimit !== token_count) {
+            if ($(input).data("settings").disabled) {
+                return false;
+            } else
+            if ($(input).data("settings").tokenLimit === null || $(input).data("settings").tokenLimit !== token_count) {
                 show_dropdown_hint();
             }
+            token_list.addClass($(input).data("settings").classes.focused);
         })
         .blur(function () {
             hide_dropdown();
+
+            if ($(input).data("settings").allowFreeTagging) {
+              add_freetagging_tokens();
+            }
+
             $(this).val("");
+            token_list.removeClass($(input).data("settings").classes.focused);
         })
         .bind("keyup keydown blur update", resize_input)
         .keydown(function (event) {
@@ -240,8 +313,8 @@ $.TokenList = function (input, url_or_data, settings) {
                         if(dropdown_item.length) {
                             select_dropdown_item(dropdown_item);
                         }
-                        return false;
                     }
+                    return false;
                     break;
 
                 case KEY.BACKSPACE:
@@ -271,9 +344,23 @@ $.TokenList = function (input, url_or_data, settings) {
                   if(selected_dropdown_item) {
                     add_token($(selected_dropdown_item).data("tokeninput"));
                     hidden_input.change();
-                    return false;
+                  } else {
+                    if ($(input).data("settings").allowFreeTagging) {
+                      if($(input).data("settings").allowTabOut && $(this).val() === "") {
+                        return true;
+                      } else {
+                        add_freetagging_tokens();
+                      }
+                    } else {
+                      $(this).val("");
+                      if($(input).data("settings").allowTabOut) {
+                        return true;
+                      }
+                    }
+                    event.stopPropagation();
+                    event.preventDefault();
                   }
-                  break;
+                  return false;
 
                 case KEY.ESCAPE:
                   hide_dropdown();
@@ -288,15 +375,21 @@ $.TokenList = function (input, url_or_data, settings) {
             }
         });
 
+    // Keep reference for placeholder
+    if (settings.placeholder)
+        input_box.attr("placeholder", settings.placeholder)
+
     // Keep a reference to the original input box
     var hidden_input = $(input)
                            .hide()
                            .val("")
                            .focus(function () {
-                               input_box.focus();
+                               focus_with_timeout(input_box);
                            })
                            .blur(function () {
                                input_box.blur();
+                               //return the object to this can be referenced in the callback functions.
+                               return hidden_input;
                            });
 
     // Keep a reference to the selected token and dropdown item
@@ -306,7 +399,7 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // The list to store the token items in
     var token_list = $("<ul />")
-        .addClass(settings.classes.tokenList)
+        .addClass($(input).data("settings").classes.tokenList)
         .click(function (event) {
             var li = $(event.target).closest("li");
             if(li && li.get(0) && $.data(li.get(0), "tokeninput")) {
@@ -318,32 +411,32 @@ $.TokenList = function (input, url_or_data, settings) {
                 }
 
                 // Focus input box
-                input_box.focus();
+                focus_with_timeout(input_box);
             }
         })
         .mouseover(function (event) {
             var li = $(event.target).closest("li");
             if(li && selected_token !== this) {
-                li.addClass(settings.classes.highlightedToken);
+                li.addClass($(input).data("settings").classes.highlightedToken);
             }
         })
         .mouseout(function (event) {
             var li = $(event.target).closest("li");
             if(li && selected_token !== this) {
-                li.removeClass(settings.classes.highlightedToken);
+                li.removeClass($(input).data("settings").classes.highlightedToken);
             }
         })
         .insertBefore(hidden_input);
 
     // The token holding the input box
     var input_token = $("<li />")
-        .addClass(settings.classes.inputToken)
+        .addClass($(input).data("settings").classes.inputToken)
         .appendTo(token_list)
         .append(input_box);
 
     // The list to store the dropdown items in
     var dropdown = $("<div>")
-        .addClass(settings.classes.dropdown)
+        .addClass($(input).data("settings").classes.dropdown)
         .appendTo("body")
         .hide();
 
@@ -364,20 +457,26 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Pre-populate list if items exist
     hidden_input.val("");
-    var li_data = settings.prePopulate || hidden_input.data("pre");
-    if(settings.processPrePopulate && $.isFunction(settings.onResult)) {
-        li_data = settings.onResult.call(hidden_input, li_data);
+    var li_data = $(input).data("settings").prePopulate || hidden_input.data("pre");
+    if($(input).data("settings").processPrePopulate && $.isFunction($(input).data("settings").onResult)) {
+        li_data = $(input).data("settings").onResult.call(hidden_input, li_data);
     }
     if(li_data && li_data.length) {
         $.each(li_data, function (index, value) {
             insert_token(value);
             checkTokenLimit();
+            input_box.attr("placeholder", null)
         });
     }
 
+    // Check if widget should initialize as disabled
+    if ($(input).data("settings").disabled) {
+        toggleDisabled(true);
+    }
+
     // Initialization is done
-    if($.isFunction(settings.onReady)) {
-        settings.onReady.call();
+    if($.isFunction($(input).data("settings").onReady)) {
+        $(input).data("settings").onReady.call();
     }
 
     //
@@ -390,11 +489,11 @@ $.TokenList = function (input, url_or_data, settings) {
                 delete_token($(this));
             }
         });
-    }
+    };
 
     this.add = function(item) {
         add_token(item);
-    }
+    };
 
     this.remove = function(item) {
         token_list.children("li").each(function() {
@@ -412,18 +511,46 @@ $.TokenList = function (input, url_or_data, settings) {
                 }
             }
         });
-    }
-    
+    };
+
     this.getTokens = function() {
-   		return saved_tokens;
-   	}
+        return saved_tokens;
+    };
+
+    this.toggleDisabled = function(disable) {
+        toggleDisabled(disable);
+    };
+
+    // Resize input to maximum width so the placeholder can be seen
+    resize_input();
 
     //
     // Private functions
     //
 
+    function escapeHTML(text) {
+      return $(input).data("settings").enableHTML ? text : _escapeHTML(text);
+    }
+
+    // Toggles the widget between enabled and disabled state, or according
+    // to the [disable] parameter.
+    function toggleDisabled(disable) {
+        if (typeof disable === 'boolean') {
+            $(input).data("settings").disabled = disable
+        } else {
+            $(input).data("settings").disabled = !$(input).data("settings").disabled;
+        }
+        input_box.attr('disabled', $(input).data("settings").disabled);
+        token_list.toggleClass($(input).data("settings").classes.disabled, $(input).data("settings").disabled);
+        // if there is any token selected we deselect it
+        if(selected_token) {
+            deselect_token($(selected_token), POSITION.END);
+        }
+        hidden_input.attr('disabled', $(input).data("settings").disabled);
+    }
+
     function checkTokenLimit() {
-        if(settings.tokenLimit !== null && token_count >= settings.tokenLimit) {
+        if($(input).data("settings").tokenLimit !== null && token_count >= $(input).data("settings").tokenLimit) {
             input_box.hide();
             hide_dropdown();
             return;
@@ -433,10 +560,13 @@ $.TokenList = function (input, url_or_data, settings) {
     function resize_input() {
         if(input_val === (input_val = input_box.val())) {return;}
 
+        // Get width left on the current line
+        var width_left = token_list.width() - input_box.offset().left - token_list.offset().left;
         // Enter new content into resizer and resize input accordingly
-        var escaped = input_val.replace(/&/g, '&amp;').replace(/\s/g,' ').replace(/</g, '&lt;').replace(/>/g, '&gt;');
-        input_resizer.html(escaped);
-        input_box.width(input_resizer.width() + 30);
+        input_resizer.html(_escapeHTML(input_val) || _escapeHTML(settings.placeholder));
+        // Get maximum width, minimum the size of input and maximum the widget's width
+        input_box.width(Math.min(token_list.width(),
+                                 Math.max(width_left, input_resizer.width() + 30)));
     }
 
     function is_printable_character(keycode) {
@@ -446,28 +576,49 @@ $.TokenList = function (input, url_or_data, settings) {
                 (keycode >= 219 && keycode <= 222));    // ( \ ) '
     }
 
+    function add_freetagging_tokens() {
+        var value = $.trim(input_box.val());
+        var tokens = value.split($(input).data("settings").tokenDelimiter);
+        $.each(tokens, function(i, token) {
+          if (!token) {
+            return;
+          }
+
+          if ($.isFunction($(input).data("settings").onFreeTaggingAdd)) {
+            token = $(input).data("settings").onFreeTaggingAdd.call(hidden_input, token);
+          }
+          var object = {};
+          object[$(input).data("settings").tokenValue] = object[$(input).data("settings").propertyToSearch] = token;
+          add_token(object);
+        });
+    }
+
     // Inner function to a token to the list
     function insert_token(item) {
-        var this_token = settings.tokenFormatter(item);
-        this_token = $(this_token)
-          .addClass(settings.classes.token)
-          .insertBefore(input_token);
+        var $this_token = $($(input).data("settings").tokenFormatter(item));
+        var readonly = item.readonly === true ? true : false;
+
+        if(readonly) $this_token.addClass($(input).data("settings").classes.tokenReadOnly);
+
+        $this_token.addClass($(input).data("settings").classes.token).insertBefore(input_token);
 
         // The 'delete token' button
-        $("<span>" + settings.deleteText + "</span>")
-            .addClass(settings.classes.tokenDelete)
-            .appendTo(this_token)
-            .click(function () {
-                delete_token($(this).parent());
-                hidden_input.change();
-                return false;
-            });
+        if(!readonly) {
+          $("<span>" + $(input).data("settings").deleteText + "</span>")
+              .addClass($(input).data("settings").classes.tokenDelete)
+              .appendTo($this_token)
+              .click(function () {
+                  if (!$(input).data("settings").disabled) {
+                      delete_token($(this).parent());
+                      hidden_input.change();
+                      return false;
+                  }
+              });
+        }
 
         // Store data on the token
-        var token_data = { };
-        token_data[settings.tokenValue] = item[settings.tokenValue];
-        token_data[settings.propertyToSearch] = item[settings.propertyToSearch];
-        $.data(this_token.get(0), "tokeninput", item);
+        var token_data = item;
+        $.data($this_token.get(0), "tokeninput", item);
 
         // Save this token for duplicate checking
         saved_tokens = saved_tokens.slice(0,selected_token_index).concat([token_data]).concat(saved_tokens.slice(selected_token_index));
@@ -479,20 +630,20 @@ $.TokenList = function (input, url_or_data, settings) {
         token_count += 1;
 
         // Check the token limit
-        if(settings.tokenLimit !== null && token_count >= settings.tokenLimit) {
+        if($(input).data("settings").tokenLimit !== null && token_count >= $(input).data("settings").tokenLimit) {
             input_box.hide();
             hide_dropdown();
         }
 
-        return this_token;
+        return $this_token;
     }
 
     // Add a token to the token list based on user input
     function add_token (item) {
-        var callback = settings.onAdd;
+        var callback = $(input).data("settings").onAdd;
 
         // See if the token already exists and select it if we don't want duplicates
-        if(token_count > 0 && settings.preventDuplicates) {
+        if(token_count > 0 && $(input).data("settings").preventDuplicates) {
             var found_existing_token = null;
             token_list.children().each(function () {
                 var existing_token = $(this);
@@ -506,14 +657,19 @@ $.TokenList = function (input, url_or_data, settings) {
             if(found_existing_token) {
                 select_token(found_existing_token);
                 input_token.insertAfter(found_existing_token);
-                input_box.focus();
+                focus_with_timeout(input_box);
                 return;
             }
         }
 
+        // Squeeze input_box so we force no unnecessary line break
+        input_box.width(0);
+
         // Insert the new tokens
-        if(settings.tokenLimit == null || token_count < settings.tokenLimit) {
+        if($(input).data("settings").tokenLimit == null || token_count < $(input).data("settings").tokenLimit) {
             insert_token(item);
+            // Remove the placeholder so it's not seen after you've added a token
+            input_box.attr("placeholder", null)
             checkTokenLimit();
         }
 
@@ -531,19 +687,21 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // Select a token in the token list
     function select_token (token) {
-        token.addClass(settings.classes.selectedToken);
-        selected_token = token.get(0);
+        if (!$(input).data("settings").disabled) {
+            token.addClass($(input).data("settings").classes.selectedToken);
+            selected_token = token.get(0);
 
-        // Hide input box
-        input_box.val("");
+            // Hide input box
+            input_box.val("");
 
-        // Hide dropdown if it is visible (eg if we clicked to select token)
-        hide_dropdown();
+            // Hide dropdown if it is visible (eg if we clicked to select token)
+            hide_dropdown();
+        }
     }
 
     // Deselect a token in the token list
     function deselect_token (token, position) {
-        token.removeClass(settings.classes.selectedToken);
+        token.removeClass($(input).data("settings").classes.selectedToken);
         selected_token = null;
 
         if(position === POSITION.BEFORE) {
@@ -558,7 +716,7 @@ $.TokenList = function (input, url_or_data, settings) {
         }
 
         // Show the input box and give it focus again
-        input_box.focus();
+        focus_with_timeout(input_box);
     }
 
     // Toggle selection of a token in the token list
@@ -580,7 +738,7 @@ $.TokenList = function (input, url_or_data, settings) {
     function delete_token (token) {
         // Remove the id from the saved list
         var token_data = $.data(token.get(0), "tokeninput");
-        var callback = settings.onDelete;
+        var callback = $(input).data("settings").onDelete;
 
         var index = token.prevAll().length;
         if(index > selected_token_index) index--;
@@ -590,10 +748,13 @@ $.TokenList = function (input, url_or_data, settings) {
         selected_token = null;
 
         // Show the input box and give it focus again
-        input_box.focus();
+        focus_with_timeout(input_box);
 
         // Remove this token from the saved list
         saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));
+        if (saved_tokens.length == 0) {
+            input_box.attr("placeholder", settings.placeholder)
+        }
         if(index < selected_token_index) selected_token_index--;
 
         // Update the hidden input
@@ -601,11 +762,11 @@ $.TokenList = function (input, url_or_data, settings) {
 
         token_count -= 1;
 
-        if(settings.tokenLimit !== null) {
+        if($(input).data("settings").tokenLimit !== null) {
             input_box
                 .show()
-                .val("")
-                .focus();
+                .val("");
+            focus_with_timeout(input_box);
         }
 
         // Execute the onDelete callback if defined
@@ -617,9 +778,12 @@ $.TokenList = function (input, url_or_data, settings) {
     // Update the hidden input box value
     function update_hidden_input(saved_tokens, hidden_input) {
         var token_values = $.map(saved_tokens, function (el) {
-            return el[settings.tokenValue];
+            if(typeof $(input).data("settings").tokenValue == 'function')
+              return $(input).data("settings").tokenValue.call(this, el);
+
+            return el[$(input).data("settings").tokenValue];
         });
-        hidden_input.val(token_values.join(settings.tokenDelimiter));
+        hidden_input.val(token_values.join($(input).data("settings").tokenDelimiter));
 
     }
 
@@ -633,34 +797,47 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: $(token_list).offset().top + $(token_list).outerHeight(),
-                left: $(token_list).offset().left,
-                zindex: 999
+                top: token_list.offset().top + token_list.outerHeight(),
+                left: token_list.offset().left,
+                width: token_list.width(),
+                'z-index': $(input).data("settings").zindex
             })
             .show();
     }
 
     function show_dropdown_searching () {
-        if(settings.searchingText) {
-            dropdown.html("<p>"+settings.searchingText+"</p>");
+        if($(input).data("settings").searchingText) {
+            dropdown.html("<p>" + escapeHTML($(input).data("settings").searchingText) + "</p>");
             show_dropdown();
         }
     }
 
     function show_dropdown_hint () {
-        if(settings.hintText) {
-            dropdown.html("<p>"+settings.hintText+"</p>");
+        if($(input).data("settings").hintText) {
+            dropdown.html("<p>" + escapeHTML($(input).data("settings").hintText) + "</p>");
             show_dropdown();
         }
     }
 
+    var regexp_special_chars = new RegExp('[.\\\\+*?\\[\\^\\]$(){}=!<>|:\\-]', 'g');
+    function regexp_escape(term) {
+        return term.replace(regexp_special_chars, '\\$&');
+    }
+
     // Highlight the query part of the search term
     function highlight_term(value, term) {
-        return value.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + term + ")(?![^<>]*>)(?![^&;]+;)", "gi"), "<b>$1</b>");
+        return value.replace(
+          new RegExp(
+            "(?![^&;]+;)(?!<[^<>]*)(" + regexp_escape(term) + ")(?![^<>]*>)(?![^&;]+;)",
+            "gi"
+          ), function(match, p1) {
+            return "<b>" + escapeHTML(p1) + "</b>";
+          }
+        );
     }
-    
+
     function find_value_and_highlight_term(template, value, term) {
-        return template.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + value + ")(?![^<>]*>)(?![^&;]+;)", "g"), highlight_term(value, term));
+        return template.replace(new RegExp("(?![^&;]+;)(?!<[^<>]*)(" + regexp_escape(value) + ")(?![^<>]*>)(?![^&;]+;)", "g"), highlight_term(value, term));
     }
 
     // Populate the results dropdown with some results
@@ -679,17 +856,21 @@ $.TokenList = function (input, url_or_data, settings) {
                 })
                 .hide();
 
+            if ($(input).data("settings").resultsLimit && results.length > $(input).data("settings").resultsLimit) {
+                results = results.slice(0, $(input).data("settings").resultsLimit);
+            }
+
             $.each(results, function(index, value) {
-                var this_li = settings.resultsFormatter(value);
-                
-                this_li = find_value_and_highlight_term(this_li ,value[settings.propertyToSearch], query);            
-                
+                var this_li = $(input).data("settings").resultsFormatter(value);
+
+                this_li = find_value_and_highlight_term(this_li ,value[$(input).data("settings").propertyToSearch], query);
+
                 this_li = $(this_li).appendTo(dropdown_ul);
-                
+
                 if(index % 2) {
-                    this_li.addClass(settings.classes.dropdownItem);
+                    this_li.addClass($(input).data("settings").classes.dropdownItem);
                 } else {
-                    this_li.addClass(settings.classes.dropdownItem2);
+                    this_li.addClass($(input).data("settings").classes.dropdownItem2);
                 }
 
                 if(index === 0) {
@@ -701,14 +882,14 @@ $.TokenList = function (input, url_or_data, settings) {
 
             show_dropdown();
 
-            if(settings.animateDropdown) {
+            if($(input).data("settings").animateDropdown) {
                 dropdown_ul.slideDown("fast");
             } else {
                 dropdown_ul.show();
             }
         } else {
-            if(settings.noResultsText) {
-                dropdown.html("<p>"+settings.noResultsText+"</p>");
+            if($(input).data("settings").noResultsText) {
+                dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
                 show_dropdown();
             }
         }
@@ -721,34 +902,34 @@ $.TokenList = function (input, url_or_data, settings) {
                 deselect_dropdown_item($(selected_dropdown_item));
             }
 
-            item.addClass(settings.classes.selectedDropdownItem);
+            item.addClass($(input).data("settings").classes.selectedDropdownItem);
             selected_dropdown_item = item.get(0);
         }
     }
 
     // Remove highlighting from an item in the results dropdown
     function deselect_dropdown_item (item) {
-        item.removeClass(settings.classes.selectedDropdownItem);
+        item.removeClass($(input).data("settings").classes.selectedDropdownItem);
         selected_dropdown_item = null;
     }
 
     // Do a search and show the "searching" dropdown if the input is longer
-    // than settings.minChars
+    // than $(input).data("settings").minChars
     function do_search() {
-        var query = input_box.val().toLowerCase();
+        var query = input_box.val();
 
         if(query && query.length) {
             if(selected_token) {
                 deselect_token($(selected_token), POSITION.AFTER);
             }
 
-            if(query.length >= settings.minChars) {
+            if(query.length >= $(input).data("settings").minChars) {
                 show_dropdown_searching();
                 clearTimeout(timeout);
 
                 timeout = setTimeout(function(){
                     run_search(query);
-                }, settings.searchDelay);
+                }, $(input).data("settings").searchDelay);
             } else {
                 hide_dropdown();
             }
@@ -760,10 +941,13 @@ $.TokenList = function (input, url_or_data, settings) {
         var cache_key = query + computeURL();
         var cached_results = cache.get(cache_key);
         if(cached_results) {
+            if ($.isFunction($(input).data("settings").onCachedResult)) {
+              cached_results = $(input).data("settings").onCachedResult.call(hidden_input, cached_results);
+            }
             populate_dropdown(query, cached_results);
         } else {
             // Are we doing an ajax search or local data search?
-            if(settings.url) {
+            if($(input).data("settings").url) {
                 var url = computeURL();
                 // Extract exisiting get params
                 var ajax_params = {};
@@ -783,38 +967,43 @@ $.TokenList = function (input, url_or_data, settings) {
 
                 // Prepare the request
                 ajax_params.headers = settings.ajaxHeaders;
-                ajax_params.data[settings.queryParam] = query;
-                ajax_params.type = settings.method;
-                ajax_params.dataType = settings.contentType;
-                if(settings.crossDomain) {
+                ajax_params.data[$(input).data("settings").queryParam] = query;
+                ajax_params.type = $(input).data("settings").method;
+                ajax_params.dataType = $(input).data("settings").contentType;
+                if($(input).data("settings").crossDomain) {
                     ajax_params.dataType = "jsonp";
                 }
 
                 // Attach the success callback
                 ajax_params.success = function(results) {
-                  if($.isFunction(settings.onResult)) {
-                      results = settings.onResult.call(hidden_input, results);
+                  cache.add(cache_key, $(input).data("settings").jsonContainer ? results[$(input).data("settings").jsonContainer] : results);
+                  if($.isFunction($(input).data("settings").onResult)) {
+                      results = $(input).data("settings").onResult.call(hidden_input, results);
                   }
-                  cache.add(cache_key, settings.jsonContainer ? results[settings.jsonContainer] : results);
 
                   // only populate the dropdown if the results are associated with the active search query
-                  if(input_box.val().toLowerCase() === query) {
-                      populate_dropdown(query, settings.jsonContainer ? results[settings.jsonContainer] : results);
+                  if(input_box.val() === query) {
+                      populate_dropdown(query, $(input).data("settings").jsonContainer ? results[$(input).data("settings").jsonContainer] : results);
                   }
                 };
 
+                // Provide a beforeSend callback
+                if (settings.onSend) {
+                  settings.onSend(ajax_params);
+                }
+
                 // Make the request
                 $.ajax(ajax_params);
-            } else if(settings.local_data) {
+            } else if($(input).data("settings").local_data) {
                 // Do the search through local data
-                var results = $.grep(settings.local_data, function (row) {
-                    return row[settings.propertyToSearch].toLowerCase().indexOf(query.toLowerCase()) > -1;
+                var results = $.grep($(input).data("settings").local_data, function (row) {
+                    return row[$(input).data("settings").propertyToSearch].toLowerCase().indexOf(query.toLowerCase()) > -1;
                 });
 
-                if($.isFunction(settings.onResult)) {
-                    results = settings.onResult.call(hidden_input, results);
-                }
                 cache.add(cache_key, results);
+                if($.isFunction($(input).data("settings").onResult)) {
+                    results = $(input).data("settings").onResult.call(hidden_input, results);
+                }
                 populate_dropdown(query, results);
             }
         }
@@ -822,12 +1011,22 @@ $.TokenList = function (input, url_or_data, settings) {
 
     // compute the dynamic URL
     function computeURL() {
-        var url = settings.url;
-        if(typeof settings.url == 'function') {
-            url = settings.url.call();
+        var url = $(input).data("settings").url;
+        if(typeof $(input).data("settings").url == 'function') {
+            url = $(input).data("settings").url.call($(input).data("settings"));
         }
         return url;
     }
+
+    // Bring browser focus to the specified object.
+    // Use of setTimeout is to get around an IE bug.
+    // (See, e.g., http://stackoverflow.com/questions/2600186/focus-doesnt-work-in-ie)
+    //
+    // obj: a jQuery object to focus()
+    function focus_with_timeout(obj) {
+        setTimeout(function() { obj.focus(); }, 50);
+    }
+
 };
 
 // Really basic cache for the results


### PR DESCRIPTION
My project needed to be able to provide a bearer token in the header. I had been working off 1.6.0, and I see that since then someone added a callback that allows modification of the ajax request, but I like keeping it more declarative.
