### PR TITLE
Allow unfiltered query when minChars < 0

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -330,7 +330,11 @@ $.TokenList = function (input, url_or_data, settings) {
 
                         return false;
                     } else if($(this).val().length === 1) {
-                        hide_dropdown();
+	                    if ($(input).data("settings").minChars < 0) {
+		                    setTimeout(function(){do_search();}, 5);
+	                    } else {
+		                    hide_dropdown();
+	                    }
                     } else {
                         // set a timeout just long enough to let this function finish.
                         setTimeout(function(){do_search();}, 5);


### PR DESCRIPTION
Trigger an unfiltered query when minChars < 0 either on focus of empty field (good for initial entry) and on backspace (newly empty field).

Use case:  we have some fields that have very few choices and it's easier to allow the user to see the list without any typing at all.  Tying it to the negative value of minChars makes this a deliberate choice of the developer.
