### PR TITLE
closing tags and using valid XML escape sequences to avoid JS errors on XHTML pages

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -28,7 +28,7 @@ var DEFAULT_SETTINGS = {
     hintText: "Type in a search term",
     noResultsText: "No results",
     searchingText: "Searching...",
-    deleteText: "&times;",
+    deleteText: "&#215;",
     animateDropdown: true,
     placeholder: null,
     theme: null,
@@ -248,7 +248,7 @@ $.TokenList = function (input, url_or_data, settings) {
     var input_val;
 
     // Create a new text input an attach keyup events
-    var input_box = $("<input type=\"text\"  autocomplete=\"off\" autocapitalize=\"off\">")
+    var input_box = $("<input type=\"text\"  autocomplete=\"off\" autocapitalize=\"off\"/>")
         .css({
             outline: "none"
         })
@@ -434,7 +434,7 @@ $.TokenList = function (input, url_or_data, settings) {
         .append(input_box);
 
     // The list to store the dropdown items in
-    var dropdown = $("<div>")
+    var dropdown = $("<div/>")
         .addClass($(input).data("settings").classes.dropdown)
         .appendTo("body")
         .hide();
@@ -843,7 +843,7 @@ $.TokenList = function (input, url_or_data, settings) {
     function populate_dropdown (query, results) {
         if(results && results.length) {
             dropdown.empty();
-            var dropdown_ul = $("<ul>")
+            var dropdown_ul = $("<ul/>")
                 .appendTo(dropdown)
                 .mouseover(function (event) {
                     select_dropdown_item($(event.target).closest("li"));


### PR DESCRIPTION
Note that sometimes people may want to use this library in pages they did not author and cannot control (e.g. in third-party libraries or in browser extension content scripts).
