### PR TITLE
Added maximum length attribute option

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -34,6 +34,7 @@ var DEFAULT_SETTINGS = {
     theme: null,
     zindex: 999,
     resultsLimit: null,
+    txtMaxLength: null,
 
     enableHTML: false,
 
@@ -373,6 +374,11 @@ $.TokenList = function (input, url_or_data, settings) {
                     break;
             }
         });
+
+    //add maxlength attribute to textbox
+    if (settings.txtMaxLength !== null) {
+        input_box.attr("maxlength", settings.txtMaxLength);
+    }
 
     // Keep reference for placeholder
     if (settings.placeholder)


### PR DESCRIPTION
When sending a key term to a database by specifying a data type (i.e.
table column data type) in stored procedure, if a user enters more than
a certain number of characters, it causes an error. So, I added the
option to limit the number of characters to the search text box.
