### PR TITLE
fix right_click+paste issue

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -273,6 +273,9 @@ $.TokenList = function (input, url_or_data, settings) {
             token_list.removeClass($(input).data("settings").classes.focused);
         })
         .bind("keyup keydown blur update", resize_input)
+        .bind("paste", function() { // fix right_click+paste issue
+            $(this).trigger("keydown");
+        })
         .keydown(function (event) {
             var previous_token;
             var next_token;


### PR DESCRIPTION
If you try to paste text in search box using right click, doesn't work.
