### PR TITLE
fixed bug that allowed backspace key to delete readonly tokens

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -746,5 +746,38 @@
         </script>
     </div>
 
+    <h2>Read Only Tokens</h2>
+    <div>
+
+        <form>
+            <input type="text" id="demo-readonly" name="blah" />
+            <input type="button" value="Submit" />
+        </form>
+        <script type="text/javascript">
+            $(document).ready(function() {
+                $("#demo-readonly").tokenInput([
+                    {id: 7, name: "Ruby"},
+                    {id: 11, name: "Python"},
+                    {id: 13, name: "JavaScript"},
+                    {id: 17, name: "ActionScript"},
+                    {id: 19, name: "Scheme"},
+                    {id: 23, name: "Lisp"},
+                    {id: 29, name: "C#"},
+                    {id: 31, name: "Fortran"},
+                    {id: 37, name: "Visual Basic"},
+                    {id: 41, name: "C"},
+                    {id: 43, name: "C++"},
+                    {id: 47, name: "Java"}
+                ], {
+                    prePopulate: [
+                        {id: 11, name: "Python", readonly: true},
+                        {id: 13, name: "JavaScript", readonly: true}
+                    ]
+                });
+
+            });
+        </script>
+    </div>
+
 </body>
 </html>

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -739,40 +739,45 @@ $.TokenList = function (input, url_or_data, settings) {
     function delete_token (token) {
         // Remove the id from the saved list
         var token_data = $.data(token.get(0), "tokeninput");
-        var callback = $(input).data("settings").onDelete;
 
-        var index = token.prevAll().length;
-        if(index > selected_token_index) index--;
+        // don't delete readonly tokens
+        if (!token_data.readonly) {
 
-        // Delete the token
-        token.remove();
-        selected_token = null;
+            var callback = $(input).data("settings").onDelete;
+                index = token.prevAll().length;
 
-        // Show the input box and give it focus again
-        focus_with_timeout(input_box);
+            if(index > selected_token_index) index--;
 
-        // Remove this token from the saved list
-        saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));
-        if (saved_tokens.length == 0) {
-            input_box.attr("placeholder", settings.placeholder)
-        }
-        if(index < selected_token_index) selected_token_index--;
+            // Delete the token
+            token.remove();
+            selected_token = null;
 
-        // Update the hidden input
-        update_hidden_input(saved_tokens, hidden_input);
-
-        token_count -= 1;
-
-        if($(input).data("settings").tokenLimit !== null) {
-            input_box
-                .show()
-                .val("");
+            // Show the input box and give it focus again
             focus_with_timeout(input_box);
-        }
 
-        // Execute the onDelete callback if defined
-        if($.isFunction(callback)) {
-            callback.call(hidden_input,token_data);
+            // Remove this token from the saved list
+            saved_tokens = saved_tokens.slice(0,index).concat(saved_tokens.slice(index+1));
+            if (saved_tokens.length == 0) {
+                input_box.attr("placeholder", settings.placeholder)
+            }
+            if(index < selected_token_index) selected_token_index--;
+
+            // Update the hidden input
+            update_hidden_input(saved_tokens, hidden_input);
+
+            token_count -= 1;
+
+            if($(input).data("settings").tokenLimit !== null) {
+                input_box
+                    .show()
+                    .val("");
+                focus_with_timeout(input_box);
+            }
+
+            // Execute the onDelete callback if defined
+            if($.isFunction(callback)) {
+                callback.call(hidden_input,token_data);
+            }
         }
     }
 


### PR DESCRIPTION
delete_token method wasn't checking if a token was readonly before deleting, so a user could either delete the token with the backspace key or by using the remove method `$("#demo-readonly").tokenInput("remove", {id: 11});`

That has now been prevented by making delete_token check the readonly status of a token
