### PR TITLE
Update jquery.tokeninput.js

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -798,7 +798,7 @@ $.TokenList = function (input, url_or_data, settings) {
         dropdown
             .css({
                 position: "absolute",
-                top: token_list.offset().top + token_list.outerHeight(),
+                top: token_list.offset().top + token_list.outerHeight(true),
                 left: token_list.offset().left,
                 width: token_list.width(),
                 'z-index': $(input).data("settings").zindex


### PR DESCRIPTION
After jQuery 1.9, the function jQuery(this).outerHeight() returns an object.
So, to use this script on 1.9+ jquery you need to change the function show_dropdown() and add a 'true' parameter in order to work properly.

```
function show_dropdown() {
    dropdown
           .css({
                position: "absolute",
                top: $(token_list).offset().top + $(token_list).outerHeight(true),
                left: $(token_list).offset().left,
                zindex: 999
            })
            .show();
}
```

Since this change will not affect previous jquery versions (tested with 1.7) it should be added to the dist.

Enjoy.
