### PR TITLE
Fix bug with selected_token_index inconsistency

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -701,6 +701,9 @@
 
               // Hide dropdown if it is visible (eg if we clicked to select token)
               hide_dropdown();
+              
+              //Update selected tokeIndex
+              selected_token_index = token.prevAll().length + 1;
           }
       }
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -702,7 +702,7 @@
               // Hide dropdown if it is visible (eg if we clicked to select token)
               hide_dropdown();
               
-              //Update selected tokeIndex
+              //Update selected_token_index
               selected_token_index = token.prevAll().length + 1;
           }
       }


### PR DESCRIPTION
The selected_token_index wasn't being updated when a duplicate token was found, causing bug #604 when the selected_token_index was later relied upon for token deletion. Added a line into the select_token method, to update the index every time a token is manually selected.

https://github.com/loopj/jquery-tokeninput/issues/604