### PR TITLE
Allows noResultsText to be set to a function.

### DIFF
--- a/demo.html
+++ b/demo.html
@@ -77,7 +77,7 @@
         $(document).ready(function() {
             $("#demo-input-custom-labels").tokenInput("http://shell.loopj.com/tokeninput/tvshows.php", {
                 hintText: "I can has tv shows?",
-                noResultsText: "O noes",
+                noResultsText: function(query, results) { return "O noes, " + results.length + ' results for <em>' + query + '</em>!'},
                 searchingText: "Meowing..."
             });
         });

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -921,10 +921,19 @@
                   dropdown_ul.show();
               }
           } else {
-              if($(input).data("settings").noResultsText) {
-                  dropdown.html("<p>" + escapeHTML($(input).data("settings").noResultsText) + "</p>");
-                  show_dropdown();
+              var settings = $(input).data("settings");
+
+              if(!settings.noResultsText) { return; }
+
+              if(typeof settings.noResultsText === 'function') {
+                escapedQuery  = escapeHTML(query);
+                noResultsText = settings.noResultsText(escapedQuery, results);
+              } else {
+                noResultsText = "<p>" + escapeHTML(noResultsSetting) + "</p>";
               }
+
+              dropdown.html(noResultsText);
+              show_dropdown();
           }
       }
 


### PR DESCRIPTION
Includes an example in demo.html.

This is particularly useful in combination with the `allowFreeTagging` option. The function receives two arguments, a HTML-escaped query string and the results array (which should always be empty).

When defined as a string the normal behaviour occurs, the string is wrapped in a paragraph element and injected into the DOM.

When defined as a function, the returned value is injected into the DOM.

So instead of _"No tag found..."_ you could have it update in real time _"Creating a new tag: Targaryen..."_. 
