### PR TITLE
Increase default z-index of dropdown

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -34,7 +34,7 @@
     animateDropdown: true,
     placeholder: null,
     theme: null,
-    zindex: 999,
+    zindex: 110000,
     resultsLimit: null,
 
     enableHTML: false,


### PR DESCRIPTION
A number of users are encountering problems when they attempt to use the plugin on a modal window, supplied by libraries such as Bootstrap and AJAX Control Toolkit. Due to the dropdown being appended to the body, if the z-index of the modal window is higher than the dropdown, it will be covered up.

See:
http://stackoverflow.com/q/23960267/1768779
http://stackoverflow.com/q/23677002/1768779
http://stackoverflow.com/q/11520861/1768779

By increasing the default value to a higher value, we'd avoid the problem in the first place. (I see very few situations where you'd WANT something to display on top of the interface.)

110000 was chosen as the value to be above Bootstrap, jquery UI, and AJAX Control Toolkit modal window values. (AJAX Control Toolkit is highest at 100001)

Note this means the ul and the dropdown have inconsistent z-index's, however, I think this is appropriate as there's the potential you'd want a modal to appear over a tokenInput field. However, any dropdown would have likely been dismissed on creation of the modal window anyway.

A demo of the bug can be seen here: http://jsfiddle.net/fsV48/8/
Manually change the default z-index value on line 37 of the Javascript box to see the change this implements.
