### PR TITLE
Respect placeholder attr on original input, unless overridden in settings.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -382,6 +382,11 @@
               }
           });
 
+      // Copy original placeholder unless overridden
+      if (!settings.placeholder) {
+        settings.placeholder = $(input).attr('placeholder')
+      }
+
       // Keep reference for placeholder
       if (settings.placeholder) {
         input_box.attr("placeholder", settings.placeholder);


### PR DESCRIPTION
Since we initialise the plugin on an existing DOM element the replacement should respect its placeholder by default. The `placeholder` setting remains, and will take precedence.
