### PR TITLE
Bump bower version and rename composer.json -> bower.json as the former is deprecated.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
     "name"         : "jquery-tokeninput",
-    "version"      : "1.6.2",
+    "version"      : "1.7.0",
     "description"  : "Tokeninput is a jQuery plugin which allows your users to select multiple items from a predefined list, using autocompletion as they type to find each item.",
     "main"         : [ "./src/jquery.tokeninput.js", "./styles/token-input.css" ],
     "homepage"     : "http://loopj.com/jquery-tokeninput",


### PR DESCRIPTION
Bower version listed is out of date to current `v1.7.0`. Also, using `composer.json` is deprecated in favor of `bower.json`
