### PR TITLE
Define a default height to the drop-down container

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -36,7 +36,7 @@
     theme: null,
     zindex: 999,
     resultsLimit: null,
-
+    maxHeight: "300px",
     enableHTML: false,
 
     resultsFormatter: function(item) {
@@ -803,6 +803,8 @@
               .css({
                   position: "absolute",
                   top: token_list.offset().top + token_list.outerHeight(true),
+                  "overflow": "auto",
+                  "max-height": $(input).data("settings").maxHeight || DEFAULT_SETTINGS.maxHeight,
                   left: token_list.offset().left,
                   width: token_list.width(),
                   'z-index': $(input).data("settings").zindex


### PR DESCRIPTION
When the data of dropdown are many, the container is expanded and it isn't cool.
I propose put an argument called "maxHeight" to denote the max height allowed to the container, and when surpasses it the "overflow: auto" work.
