### PR TITLE
Added 'token-input-has-token' class to allow for styling of empty field state

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -76,6 +76,7 @@
   // Default classes to use when theming
   var DEFAULT_CLASSES = {
     tokenList            : "token-input-list",
+    tokenListHasToken    : "token-input-has-token",
     token                : "token-input-token",
     tokenReadOnly        : "token-input-token-readonly",
     tokenDelete          : "token-input-delete-token",
@@ -795,9 +796,18 @@
       function hide_dropdown () {
           dropdown.hide().empty();
           selected_dropdown_item = null;
+          
+          // Removes class from token list if it contains no tokens
+	      if(token_count == 0) {
+		      token_list.removeClass(settings.classes.tokenListHasToken);
+	      }
       }
 
       function show_dropdown() {
+          
+          // Adds class to token list if it contains tokens
+    	  token_list.addClass(settings.classes.tokenListHasToken);
+          
           dropdown
               .css({
                   position: "absolute",


### PR DESCRIPTION
Added class 'token-input-has-token' to enable css to distinguish when a token input has content or not. I have needed this a few times to enable styling of token-input when empty.
