### PR TITLE
Updated search function to hide dropdown on no query; stop triggering new searches on SHIFT/CTRL

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -965,6 +965,8 @@
               } else {
                   hide_dropdown();
               }
+          } else {
+              hide_dropdown();
           }
       }
 

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -113,7 +113,9 @@
     RIGHT        : 39,
     DOWN         : 40,
     NUMPAD_ENTER : 108,
-    COMMA        : 188
+    COMMA        : 188,
+    CTRL:        : 17,
+    SHIFT:       : 16
   };
 
   var HTML_ESCAPES = {
@@ -370,6 +372,10 @@
 
                   case KEY.ESCAPE:
                     hide_dropdown();
+                    return true;
+                    
+                  case KEY.CTRL:
+                  case KEY.SHIFT:
                     return true;
 
                   default:


### PR DESCRIPTION
The dropdown still displays when all text is cut from the input box (CTRL+A, CTRL+X) so, for some data sources, the 'searching' text then displays indefinitely. This change removes the dropdown when the search field is empty.

Searches are also triggered when hitting the SHIFT or CTRL keys while focused on the input. These are now ignored.
