### PR TITLE
Width token input dropdown

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -801,7 +801,7 @@
           dropdown
               .css({
                   position: "absolute",
-				  width: $(token_list).width(),
+                  width: $(token_list).width(),
                   top: token_list.offset().top + token_list.outerHeight(true),
                   left: token_list.offset().left,
                   width: token_list.width(),

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -801,6 +801,7 @@
           dropdown
               .css({
                   position: "absolute",
+				  width: $(token_list).width(),
                   top: token_list.offset().top + token_list.outerHeight(true),
                   left: token_list.offset().left,
                   width: token_list.width(),


### PR DESCRIPTION
When the token-input-list width isn't fixed, we should set token-input-dropdown width as the same current width of token-input-list. 
