### PR TITLE
ingore exception on focus on disabled element

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -1068,7 +1068,11 @@
       function focusWithTimeout(object) {
           setTimeout(
             function() {
-			  object.focus();
+			  try {
+			  	object.focus();
+			  } catch(e) {
+			  	// ignore exception
+			  }
             },
 			50
 		  );


### PR DESCRIPTION
Ignore exception when trying to focus on a disabled element using IE8
