### PR TITLE
Display/positioning improvements

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -32,6 +32,7 @@
     animateDropdown: true,
     placeholder: null,
     theme: null,
+    width: null,
     zindex: 999,
     cursorDropdown: false,
     resultsLimit: null,
@@ -799,7 +800,7 @@
       }
 
       function show_dropdown() {
-          var top, left;
+          var top, left, width;
 
           top = $(input).data("settings").cursorDropdown ?
                 input_box.offset().top + input_box.outerHeight(true) :
@@ -807,13 +808,17 @@
           left = $(input).data("settings").cursorDropdown ?
                  input_box.offset().left :
                  token_list.offset().left;
+          width = $(input).data("settings").width;
+          if (!width) {
+              width = token_list.width();
+          }
 
           dropdown
               .css({
                   position: "absolute",
                   top: top,
                   left: left,
-                  width: token_list.width(),
+                  width: width,
                   'z-index': $(input).data("settings").zindex
               })
               .show();

--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -33,6 +33,7 @@
     placeholder: null,
     theme: null,
     zindex: 999,
+    cursorDropdown: false,
     resultsLimit: null,
 
     enableHTML: false,
@@ -798,11 +799,20 @@
       }
 
       function show_dropdown() {
+          var top, left;
+
+          top = $(input).data("settings").cursorDropdown ?
+                input_box.offset().top + input_box.outerHeight(true) :
+                token_list.offset().top + token_list.outerHeight(true);
+          left = $(input).data("settings").cursorDropdown ?
+                 input_box.offset().left :
+                 token_list.offset().left;
+
           dropdown
               .css({
                   position: "absolute",
-                  top: token_list.offset().top + token_list.outerHeight(true),
-                  left: token_list.offset().left,
+                  top: top,
+                  left: left,
                   width: token_list.width(),
                   'z-index': $(input).data("settings").zindex
               })


### PR DESCRIPTION
Commit messages say everything, I think it's a good idea to have two options for controlling the dropdown positioning (cursorDropdown makes tokeninput dropdown behave like the jquery.tagit one) and the dropdown width (in previous versions it was possible to override it through css, but before my patch it was fixed to textbox length...)
