### PR TITLE
Calling destroy should remove the dropdown div.

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -173,6 +173,7 @@
       destroy: function () {
         if (this.data("tokenInputObject")) {
           this.data("tokenInputObject").clear();
+          this.data("tokenInputObject").removeDropdown();
           var tmpInput = this;
           var closest = this.parent();
           closest.empty();
@@ -500,6 +501,10 @@
                   delete_token($(this));
               }
           });
+      };
+      
+      this.removeDropdown = function() {
+      	$(dropdown).remove();
       };
 
       this.add = function(item) {


### PR DESCRIPTION
Upon init, a div is appended to the body.  This commit makes the plugin fully clean up after itself by removing that div when destroy is called.
