### PR TITLE
Fix :  multi input value , and then select dropdown item no response and no selected style

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -377,6 +377,7 @@
                       // set a timeout just long enough to let this function finish.
                       setTimeout(function(){ do_search(); }, 5);
                     }
+                    selected_dropdown_item = null;
                     break;
               }
           });


### PR DESCRIPTION
After inputing first value , you can select dropdown item and see the selected class style in the first time , when you input another value follow the first value , the key down operation will loose response , and you can not see the selected style at the dropdown list . 

clean the value "selected_dropdown_item" to null when you multi input values.