### PR TITLE
Allow < (less than) sign

### DIFF
--- a/src/jquery.tokeninput.js
+++ b/src/jquery.tokeninput.js
@@ -347,26 +347,28 @@
                   case KEY.ENTER:
                   case KEY.NUMPAD_ENTER:
                   case KEY.COMMA:
-                    if(selected_dropdown_item) {
-                      add_token($(selected_dropdown_item).data("tokeninput"));
-                      hiddenInput.change();
-                    } else {
-                      if ($(input).data("settings").allowFreeTagging) {
-                        if($(input).data("settings").allowTabOut && $(this).val() === "") {
-                          return true;
-                        } else {
-                          add_freetagging_tokens();
-                        }
+                    if (!event.shiftKey) { //Allow < (less than) sign
+                      if(selected_dropdown_item) {
+                        add_token($(selected_dropdown_item).data("tokeninput"));
+                        hiddenInput.change();
                       } else {
-                        $(this).val("");
-                        if($(input).data("settings").allowTabOut) {
-                          return true;
+                          if ($(input).data("settings").allowFreeTagging) {
+                            if($(input).data("settings").allowTabOut && $(this).val() === "") {
+                              return true;
+                            } else {
+                              add_freetagging_tokens();
+                            }
+                          } else {
+                            $(this).val("");
+                            if($(input).data("settings").allowTabOut) {
+                              return true;
+                          }
                         }
+                        event.stopPropagation();
+                        event.preventDefault();
                       }
-                      event.stopPropagation();
-                      event.preventDefault();
+                      return false;
                     }
-                    return false;
 
                   case KEY.ESCAPE:
                     hide_dropdown();


### PR DESCRIPTION
Currently pressing the < (less than) sign emulates the same Key Code as Comma, hence it was being treated as a Delimiter. Adding the Shift Key check, eliminates this issue.